### PR TITLE
[ALS-7112] BDC Data Dictionary: Data dictionary needs to support AWS secrets rotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ COPY --from=build target/dictionary-*.jar /dictionary.jar
 # Time zone
 ENV TZ="US/Eastern"
 
-ENTRYPOINT java $DEBUG_VARS $PROXY_VARS -Xmx8192m -jar /dictionary.jar
+# Default to no profile
+ENTRYPOINT java $DEBUG_VARS $PROXY_VARS -Xmx8192m -jar /dictionary.jar --spring.profiles.active=${SPRING_PROFILE:-}

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws.secretsmanager</groupId>
+			<artifactId>aws-secretsmanager-jdbc</artifactId>
+			<version>2.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -1,6 +1,6 @@
 spring.application.name=dictionary
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:mysql://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.url=jdbc-secretsmanager:postgres://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -1,0 +1,6 @@
+spring.application.name=dictionary
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
+spring.datasource.url=jdbc-secretsmanager:mysql://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.username=${DATASOURCE_USERNAME}
+server.port=80


### PR DESCRIPTION
- Dockerfile now includes `--spring.profiles.active=${SPRING_PROFILE:-}`. This allows user to specify a different spring profile if necessary.
- Created application-bdc.properties that includes BDC specific database configuration for PostgreSQL. This configuration allows the application to use aws secrets manger for its username and password.
- Included `aws-secretsmanager-jdbc` dependency.

Example use of docker with `bdc` set for the spring profile.
`docker run -e SPRING_PROFILE=bdc`