### PR TITLE
[ALS-7051] BDC: Deploy Data Dictionary API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,14 @@ COPY --from=build target/dictionary-*.jar /dictionary.jar
 # Time zone
 ENV TZ="US/Eastern"
 
+ARG DATASOURCE_URL
+ARG DATASOURCE_USERNAME
+ARG SPRING_PROFILE
+
 # If a --env-file is passed in, you can override these values
 ENV DATASOURCE_URL=${DATASOURCE_URL}
 ENV DATASOURCE_USERNAME=${DATASOURCE_USERNAME}
+ENV SPRING_PROFILE=${SPRING_PROFILE}
 
 # Default to no profile
 ENTRYPOINT java $DEBUG_VARS $PROXY_VARS -Xmx8192m -jar /dictionary.jar --spring.profiles.active=${SPRING_PROFILE:-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,9 @@ COPY --from=build target/dictionary-*.jar /dictionary.jar
 # Time zone
 ENV TZ="US/Eastern"
 
+# If a --env-file is passed in, you can override these values
+ENV DATASOURCE_URL=${DATASOURCE_URL}
+ENV DATASOURCE_USERNAME=${DATASOURCE_USERNAME}
+
 # Default to no profile
 ENTRYPOINT java $DEBUG_VARS $PROXY_VARS -Xmx8192m -jar /dictionary.jar --spring.profiles.active=${SPRING_PROFILE:-}

--- a/dictionaryweights/Dockerfile
+++ b/dictionaryweights/Dockerfile
@@ -13,4 +13,13 @@ FROM amazoncorretto:22-alpine
 # Copy jar and access token from maven build
 COPY --from=build target/dictionaryweights-*.jar /dictionaryweights.jar
 
-ENTRYPOINT java -jar /dictionaryweights.jar
+ARG DATASOURCE_URL
+ARG DATASOURCE_USERNAME
+ARG SPRING_PROFILE
+
+# If a --env-file is passed in, you can override these values
+ENV DATASOURCE_URL=${DATASOURCE_URL}
+ENV DATASOURCE_USERNAME=${DATASOURCE_USERNAME}
+ENV SPRING_PROFILE=${SPRING_PROFILE}
+
+ENTRYPOINT java -jar /dictionaryweights.jar --spring.profiles.active=${SPRING_PROFILE:-}

--- a/dictionaryweights/pom.xml
+++ b/dictionaryweights/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws.secretsmanager</groupId>
+			<artifactId>aws-secretsmanager-jdbc</artifactId>
+			<version>2.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/DataSourceVerifier.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/DataSourceVerifier.java
@@ -1,0 +1,39 @@
+package edu.harvard.dbmi.avillach.dictionary.datasource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Service
+public class DataSourceVerifier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataSourceVerifier.class);
+
+    private final DataSource dataSource;
+
+    @Autowired
+    public DataSourceVerifier(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @EventListener(ContextRefreshedEvent.class)
+    public void verifyDataSourceConnection() {
+        try (Connection connection = dataSource.getConnection()) {
+            if (connection != null) {
+                LOG.info("Datasource connection verified successfully.");
+            } else {
+                LOG.info("Failed to obtain a connection from the datasource.");
+            }
+        } catch (SQLException e) {
+            LOG.info("Error verifying datasource connection: {}", e.getMessage());
+        }
+    }
+
+}

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -1,0 +1,9 @@
+spring.application.name=dictionaryweights
+spring.main.web-application-type=none
+
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:5432/dict?currentSchema=dict
+spring.datasource.username=${POSTGRES_USER}
+spring.datasource.password=${POSTGRES_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+weights.filename=/weights.csv

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -1,9 +1,9 @@
 spring.application.name=dictionaryweights
 spring.main.web-application-type=none
 
-spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:5432/dict?currentSchema=dict
-spring.datasource.username=${POSTGRES_USER}
-spring.datasource.password=${POSTGRES_PASSWORD}
-spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.username=${DATASOURCE_USERNAME}
 
 weights.filename=/weights.csv

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -3,7 +3,7 @@ spring.main.web-application-type=none
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
 spring.datasource.username=${DATASOURCE_USERNAME}
 
 weights.filename=/weights.csv

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -3,7 +3,7 @@ spring.main.web-application-type=none
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
 spring.datasource.username=${DATASOURCE_USERNAME}
 
 weights.filename=/weights.csv

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -3,7 +3,8 @@ spring.main.web-application-type=none
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
+spring.datasource.schema=dict
 
 weights.filename=/weights.csv

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -3,7 +3,7 @@ spring.main.web-application-type=none
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
 spring.datasource.username=${DATASOURCE_USERNAME}
 
 weights.filename=/weights.csv

--- a/dictionaryweights/src/main/resources/application-bdc.properties
+++ b/dictionaryweights/src/main/resources/application-bdc.properties
@@ -5,6 +5,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
 spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
-spring.datasource.schema=dict
 
 weights.filename=/weights.csv

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/datasource/DataSourceVerifier.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/datasource/DataSourceVerifier.java
@@ -1,0 +1,39 @@
+package edu.harvard.dbmi.avillach.dictionary.datasource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Service
+public class DataSourceVerifier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataSourceVerifier.class);
+
+    private final DataSource dataSource;
+
+    @Autowired
+    public DataSourceVerifier(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @EventListener(ContextRefreshedEvent.class)
+    public void verifyDataSourceConnection() {
+        try (Connection connection = dataSource.getConnection()) {
+            if (connection != null) {
+                LOG.info("Datasource connection verified successfully.");
+            } else {
+                LOG.info("Failed to obtain a connection from the datasource.");
+            }
+        } catch (SQLException e) {
+            LOG.info("Error verifying datasource connection: {}", e.getMessage());
+        }
+    }
+
+}

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -1,6 +1,6 @@
 spring.application.name=dictionary
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/picsure?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -1,7 +1,7 @@
 spring.application.name=dictionary
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80
 

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -4,9 +4,3 @@ spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsM
 spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80
-
-# make datasource logs verbose for debugging
-logging.level.com.amazonaws.secretsmanager.sql=DEBUG
-
-# Make application logs verbose for debugging
-logging.level.org.springframework=DEBUG

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -1,7 +1,7 @@
 spring.application.name=dictionary
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgres://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80
 

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -4,3 +4,9 @@ spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsM
 spring.datasource.url=jdbc-secretsmanager:postgres://${DATASOURCE_URL}/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80
+
+# make datasource logs verbose for debugging
+logging.level.com.amazonaws.secretsmanager.sql=DEBUG
+
+# Make application logs verbose for debugging
+logging.level.org.springframework=DEBUG

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -1,6 +1,6 @@
 spring.application.name=dictionary
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
-spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true
+spring.datasource.url=jdbc-secretsmanager:postgresql://${DATASOURCE_URL}/dict?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&currentSchema=dict
 spring.datasource.username=${DATASOURCE_USERNAME}
 server.port=80


### PR DESCRIPTION
- Added a new maven dependency to both services to use AWS Secrets Manager as its source of truth for database connection configuration. This allows teams to rotate passwords on AWS on a schedule without experiencing service disruptions.
```
<dependency>
  <groupId>com.amazonaws.secretsmanager</groupId>
  <artifactId>aws-secretsmanager-jdbc</artifactId>
  <version>2.0.2</version>
</dependency>
```

- Added `application-bdc.properties` for both services. This properties file is used to connect to a secrets manager. The `DATASOURCE` is the domain for the database. The `DATASOURCE_USERNAME` is the name of the secret you intend to use. 

- Added `DataSourceVerifier` to both services. This is class will report the status of the database connection on start up. This is useful when you need to verify that the database connect is working before any request are sent by the application.
