### PR TITLE
Refactor legacy search query processing

### DIFF
--- a/dictonaryReqeust.http
+++ b/dictonaryReqeust.http
@@ -12,4 +12,5 @@ Content-Type: application/json
 POST http://localhost:80/search
 Content-Type: application/json
 
-{"@type":"GeneralQueryRequest","resourceCredentials":{},"query":{"searchTerm":"breast","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":10000000},"resourceUUID":null}
+{"@type":"GeneralQueryRequest","resourceCredentials":{},"query":{"searchTerm":"throat sore acute #8","includedTags":[],
+  "excludedTags":[],"returnTags":"true","offset":0,"limit":100000},"resourceUUID":null}

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapper.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapper.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import edu.harvard.dbmi.avillach.dictionary.legacysearch.model.LegacySearchQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +19,7 @@ import java.util.stream.Collectors;
 public class LegacySearchQueryMapper {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Logger log = LoggerFactory.getLogger(LegacySearchQueryMapper.class);
 
     public LegacySearchQueryMapper() {}
 
@@ -26,7 +29,9 @@ public class LegacySearchQueryMapper {
 
         String searchTerm = queryNode.get("searchTerm").asText();
         int limit = queryNode.get("limit").asInt();
-        return new LegacySearchQuery(new Filter(List.of(), constructTsQuery(searchTerm), List.of()), PageRequest.of(0, limit));
+        searchTerm = constructTsQuery(searchTerm);
+        log.debug("Constructed Search Term: {}", searchTerm);
+        return new LegacySearchQuery(new Filter(List.of(), searchTerm, List.of()), PageRequest.of(0, limit));
     }
 
     // An attempt to provide OR search that will produce similar results to legacy search-prototype

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapper.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapper.java
@@ -3,23 +3,22 @@ package edu.harvard.dbmi.avillach.dictionary.legacysearch;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
-import edu.harvard.dbmi.avillach.dictionary.filter.FilterProcessor;
 import edu.harvard.dbmi.avillach.dictionary.legacysearch.model.LegacySearchQuery;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class LegacySearchQueryMapper {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private final FilterProcessor filterProcessor;
 
-    public LegacySearchQueryMapper(FilterProcessor filterProcessor) {
-        this.filterProcessor = filterProcessor;
-    }
+    public LegacySearchQueryMapper() {}
 
     public LegacySearchQuery mapFromJson(String jsonString) throws IOException {
         JsonNode rootNode = objectMapper.readTree(jsonString);
@@ -27,8 +26,31 @@ public class LegacySearchQueryMapper {
 
         String searchTerm = queryNode.get("searchTerm").asText();
         int limit = queryNode.get("limit").asInt();
-        Filter filter = filterProcessor.processsFilter(new Filter(List.of(), searchTerm, List.of()));
-        return new LegacySearchQuery(filter, PageRequest.of(0, limit));
+        return new LegacySearchQuery(new Filter(List.of(), constructTsQuery(searchTerm), List.of()), PageRequest.of(0, limit));
+    }
+
+    // An attempt to provide OR search that will produce similar results to legacy search-prototype
+    private String constructTsQuery(String searchTerm) {
+        // Split on the | to enable or queries
+        String[] orGroups = searchTerm.split("\\|");
+        List<String> orClauses = new ArrayList<>();
+
+        for (String group : orGroups) {
+            // To replicate legacy search we will split using its regex [\\s\\p{Punct}]+
+            String[] tokens = group.trim().split("[\\s\\p{Punct}]+");
+
+            // Now we will combine the tokens in this group and '&' them together.
+            String andClause = Arrays.stream(tokens).filter(token -> !token.isBlank()) // remove empty tokens.
+                .map(token -> token + ":*") // add the wild card for search
+                .collect(Collectors.joining(" & "));
+
+            if (!andClause.isBlank()) {
+                orClauses.add(andClause);
+            }
+        }
+
+
+        return String.join(" | ", orClauses);
     }
 
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchRepository.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchRepository.java
@@ -35,7 +35,7 @@ public class LegacySearchRepository {
     }
 
     public List<SearchResult> getLegacySearchResults(Filter filter, Pageable pageable) {
-        QueryParamPair filterQ = filterGen.generateFilterQuery(filter, pageable);
+        QueryParamPair filterQ = filterGen.generateLegacyFilterQuery(filter, pageable);
         String sql = ALLOW_FILTERING_Q + ", " + filterQ.query() + """
                 SELECT concept_node.concept_path  AS conceptPath,
                    concept_node.display           AS display,

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchControllerIntegrationTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchControllerIntegrationTest.java
@@ -57,17 +57,34 @@ class LegacySearchControllerIntegrationTest {
     @Test
     void shouldHandleORRequest() throws IOException {
         String jsonString = """
-            {"query":{"searchTerm":"physical|age","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
+            {"query":{"searchTerm":"age","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
             """;
 
         ResponseEntity<LegacyResponse> legacyResponseResponseEntity = legacySearchController.legacySearch(jsonString);
-        System.out.println(legacyResponseResponseEntity);
         Assertions.assertEquals(HttpStatus.OK, legacyResponseResponseEntity.getStatusCode());
         LegacyResponse legacyResponseBody = legacyResponseResponseEntity.getBody();
         Assertions.assertNotNull(legacyResponseBody);
         Results results = legacyResponseBody.results();
-        List<SearchResult> searchResults = results.searchResults();
-        System.out.println(searchResults);
+        List<SearchResult> ageSearchResults = results.searchResults();
+        Assertions.assertEquals(4, ageSearchResults.size());
+
+        jsonString = """
+            {"query":{"searchTerm":"physical|age","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
+            """;
+
+        legacyResponseResponseEntity = legacySearchController.legacySearch(jsonString);
+        Assertions.assertEquals(HttpStatus.OK, legacyResponseResponseEntity.getStatusCode());
+        legacyResponseBody = legacyResponseResponseEntity.getBody();
+        Assertions.assertNotNull(legacyResponseBody);
+        results = legacyResponseBody.results();
+        List<SearchResult> physicalORAgeSearchResults = results.searchResults();
+        Assertions.assertEquals(5, physicalORAgeSearchResults.size());
+
+        // Verify that age|physical has expanded the search results
+        Assertions.assertNotEquals(ageSearchResults.size(), physicalORAgeSearchResults.size());
+
+        // Verify the OR statement has more results
+        Assertions.assertTrue(ageSearchResults.size() < physicalORAgeSearchResults.size());
     }
 
 

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchControllerIntegrationTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchControllerIntegrationTest.java
@@ -54,4 +54,21 @@ class LegacySearchControllerIntegrationTest {
         searchResults.forEach(searchResult -> Assertions.assertEquals("phs000007", searchResult.result().studyId()));
     }
 
+    @Test
+    void shouldHandleORRequest() throws IOException {
+        String jsonString = """
+            {"query":{"searchTerm":"physical|age","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
+            """;
+
+        ResponseEntity<LegacyResponse> legacyResponseResponseEntity = legacySearchController.legacySearch(jsonString);
+        System.out.println(legacyResponseResponseEntity);
+        Assertions.assertEquals(HttpStatus.OK, legacyResponseResponseEntity.getStatusCode());
+        LegacyResponse legacyResponseBody = legacyResponseResponseEntity.getBody();
+        Assertions.assertNotNull(legacyResponseBody);
+        Results results = legacyResponseBody.results();
+        List<SearchResult> searchResults = results.searchResults();
+        System.out.println(searchResults);
+    }
+
+
 }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapperTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapperTest.java
@@ -47,4 +47,32 @@ class LegacySearchQueryMapperTest {
         Assertions.assertEquals(100, pageable.getPageSize());
     }
 
+    @Test
+    void shouldHandleOR() throws IOException {
+        String jsonString = """
+            {"query":{"searchTerm":"sex|gender","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
+            """;
+
+        LegacySearchQuery legacySearchQuery = legacySearchQueryMapper.mapFromJson(jsonString);
+        Filter filter = legacySearchQuery.filter();
+        Pageable pageable = legacySearchQuery.pageable();
+
+        Assertions.assertEquals("sex:* | gender:*", filter.search());
+        Assertions.assertEquals(100, pageable.getPageSize());
+    }
+
+    @Test
+    void shouldHandleORAndPunct() throws IOException {
+        String jsonString = """
+            {"query":{"searchTerm":"sex|gender age","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
+            """;
+
+        LegacySearchQuery legacySearchQuery = legacySearchQueryMapper.mapFromJson(jsonString);
+        Filter filter = legacySearchQuery.filter();
+        Pageable pageable = legacySearchQuery.pageable();
+
+        Assertions.assertEquals("sex:* | gender:* & age:*", filter.search());
+        Assertions.assertEquals(100, pageable.getPageSize());
+    }
+
 }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapperTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchQueryMapperTest.java
@@ -28,12 +28,12 @@ class LegacySearchQueryMapperTest {
         Filter filter = legacySearchQuery.filter();
         Pageable pageable = legacySearchQuery.pageable();
 
-        Assertions.assertEquals("age", filter.search());
+        Assertions.assertEquals("age:*", filter.search());
         Assertions.assertEquals(100, pageable.getPageSize());
     }
 
     @Test
-    void shouldReplaceUnderscore() throws IOException {
+    void shouldHandlePunct() throws IOException {
         String jsonString =
             """
                 {"query":{"searchTerm":"tutorial-biolincc_digitalis","includedTags":[],"excludedTags":[],"returnTags":"true","offset":0,"limit":100}}
@@ -43,7 +43,7 @@ class LegacySearchQueryMapperTest {
         Filter filter = legacySearchQuery.filter();
         Pageable pageable = legacySearchQuery.pageable();
 
-        Assertions.assertEquals("tutorial-biolincc/digitalis", filter.search());
+        Assertions.assertEquals("tutorial:* & biolincc:* & digitalis:*", filter.search());
         Assertions.assertEquals(100, pageable.getPageSize());
     }
 


### PR DESCRIPTION
Refactor LegacySearchQueryMapper to handle logical OR and punctuation in search terms, removing dependency on FilterProcessor. Update ConceptFilterQueryGenerator with generateLegacyFilterQuery and simplify query construction. Adjust LegacySearchRepository to align with new query generation logic.