### PR TITLE
[ALS-7760] Minor Logic Fix

### DIFF
--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/MetadataResultSetUtil.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/MetadataResultSetUtil.java
@@ -96,14 +96,14 @@ public class MetadataResultSetUtil {
     }
 
     private String getParentDisplay(ResultSet rs) throws SQLException {
-        return StringUtils.hasLength("parentDisplay") ? "" : rs.getString("parentDisplay");
+        return StringUtils.hasLength("parentDisplay") ? rs.getString("parentDisplay") : "";
     }
 
     private String getParentName(ResultSet rs) throws SQLException {
-        return StringUtils.hasLength(rs.getString("parentName")) ? "All Variables" : rs.getString("parentName");
+        return StringUtils.hasLength(rs.getString("parentName")) ? rs.getString("parentName") : "All Variables";
     }
 
     private String getDescription(ResultSet rs) throws SQLException {
-        return StringUtils.hasLength(rs.getString("description")) ? "" : rs.getString("description");
+        return StringUtils.hasLength(rs.getString("description")) ? rs.getString("description") : "";
     }
 }


### PR DESCRIPTION
Corrected the conditional checks for 'parentDisplay', 'parentName', and 'description' in the MetadataResultSetUtil class. This ensures that non-empty strings are returned appropriately, enhancing the accuracy of metadata retrieval.