### PR TITLE
[ALS-7415] - Force value matches to top of search results

### DIFF
--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptRepositoryTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptRepositoryTest.java
@@ -45,7 +45,7 @@ class ConceptRepositoryTest {
     void shouldListAllConcepts() {
         List<Concept> actual = subject.getConcepts(new Filter(List.of(), "", List.of()), Pageable.unpaged());
 
-        Assertions.assertEquals(30, actual.size());
+        Assertions.assertEquals(31, actual.size());
     }
 
     @Test
@@ -139,7 +139,7 @@ class ConceptRepositoryTest {
     void shouldGetCount() {
         long actual = subject.countConcepts(new Filter(List.of(), "", List.of()));
 
-        Assertions.assertEquals(30L, actual);
+        Assertions.assertEquals(31L, actual);
     }
 
     @Test

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/filter/ConceptFilterQueryGeneratorTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/filter/ConceptFilterQueryGeneratorTest.java
@@ -41,6 +41,28 @@ class ConceptFilterQueryGeneratorTest {
     NamedParameterJdbcTemplate template;
 
     @Test
+    void shouldSortValueMatchesAboveSearchMatches() {
+        Filter filter = new Filter(List.of(), "origin", List.of());
+        QueryParamPair pair = subject.generateFilterQuery(filter, Pageable.unpaged());
+        String query = "WITH " + pair.query() + "\n SELECT concept_node_id FROM concepts_filtered_sorted;";
+
+        List<Integer> actual = template.queryForList(query, pair.params(), Integer.class);
+
+        Assertions.assertEquals(List.of(271, 270), actual);
+    }
+
+    @Test
+    void shouldFindValuesNotInSearchString() {
+        Filter filter = new Filter(List.of(), "gremlin", List.of());
+        QueryParamPair pair = subject.generateFilterQuery(filter, Pageable.unpaged());
+        String query = "WITH " + pair.query() + "\n SELECT concept_node_id FROM concepts_filtered_sorted;";
+
+        List<Integer> actual = template.queryForList(query, pair.params(), Integer.class);
+
+        Assertions.assertEquals(List.of(271), actual);
+    }
+
+    @Test
     void shouldPutStigvarsLastForEmptySearch() {
         Filter filter = new Filter(List.of(), "", List.of());
         QueryParamPair pair = subject.generateFilterQuery(filter, Pageable.unpaged());
@@ -58,7 +80,7 @@ class ConceptFilterQueryGeneratorTest {
         String query = "WITH " + pair.query() + "\n SELECT concept_node_id FROM concepts_filtered_sorted;";
 
         List<Integer> actual = template.queryForList(query, pair.params(), Integer.class);
-        List<Integer> expected = List.of(270);
+        List<Integer> expected = List.of(270, 271);
 
         Assertions.assertEquals(expected, actual);
     }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchRepositoryTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/legacysearch/LegacySearchRepositoryTest.java
@@ -44,7 +44,7 @@ public class LegacySearchRepositoryTest {
     void shouldGetLegacySearchResults() {
         List<SearchResult> searchResults = subject.getLegacySearchResults(new Filter(List.of(), "", List.of()), Pageable.unpaged());
 
-        Assertions.assertEquals(30, searchResults.size());
+        Assertions.assertEquals(31, searchResults.size());
     }
 
     @Test

--- a/src/test/resources/seed.sql
+++ b/src/test/resources/seed.sql
@@ -396,6 +396,7 @@ COPY public.concept_node (concept_node_id, dataset_id, name, display, concept_ty
 268	14	WES	WES	categorical	\\Variant Data Type\\WES\\	265	'data':2 'exom':7 'sequenc':8 'true':9 'type':3 'variant':1 'wes':4,5 'whole':6
 269	14	WGS	WGS	categorical	\\Variant Data Type\\WGS\\	265	'data':2 'genom':7 'sequenc':8 'true':9 'type':3 'variant':1 'wgs':4,5 'whole':6
 270	26	harmonized_var	harmonized_var	continuous	\\phs003566\\harmonized_var\\	263	'ecgsamplebas':5,8 'origin':4,7 'phs003566':1 'visit01':2,3,6
+271	26	value_example	value_example	continuous	\\phs003566\\value_example\\	263	'ecgsamplebas':5,8 'origin':4,7 'phs003566':1 'visit01':2,3,6
 \.
 
 
@@ -520,6 +521,7 @@ COPY public.concept_node_meta (concept_node_meta_id, concept_node_id, key, value
 36	222	values	[0, 150]
 66	242	values	[0, 30]
 134	270	values	[0, 21]
+135	271	values	['gremlin', 'origin']
 \.
 
 


### PR DESCRIPTION
- We have some value strings that are enormous. Those strings get excluded from the traditional search because of their length. To fix this, we run a quick LIKE on the values field on the raw search string