### PR TITLE
[ALS-8545] Set up file-based logging configuration

### DIFF
--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -8,3 +8,7 @@ server.port=80
 dashboard.enable.extra_details=true
 
 filtering.unfilterable_concepts=stigmatized
+
+# Logging File Output https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.file-output
+# If you are adding additional log files please add them to /var/log/ directory.
+logging.file.name=/var/log/dictionary.log


### PR DESCRIPTION
Added a logging file output path to store logs in /var/log/directory as per guidelines. Updated application-bdc.properties to reflect this new configuration for better log management and accessibility.