### PR TITLE
Refactor to replace Float with Double for ContinuousConcept

### DIFF
--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/model/ContinuousConcept.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/model/ContinuousConcept.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 public record ContinuousConcept(
     String conceptPath, String name, String display, String dataset, String description, boolean allowFiltering,
 
-    @Nullable Float min, @Nullable Float max, String studyAcronym, Map<String, String> meta, @Nullable List<Concept> children,
+    @Nullable Double min, @Nullable Double max, String studyAcronym, Map<String, String> meta, @Nullable List<Concept> children,
 
     @Nullable Concept table,
 
@@ -19,8 +19,8 @@ public record ContinuousConcept(
 ) implements Concept {
 
     public ContinuousConcept(
-        String conceptPath, String name, String display, String dataset, String description, boolean allowFiltering, @Nullable Float min,
-        @Nullable Float max, String studyAcronym, Map<String, String> meta, @Nullable List<Concept> children
+        String conceptPath, String name, String display, String dataset, String description, boolean allowFiltering, @Nullable Double min,
+        @Nullable Double max, String studyAcronym, Map<String, String> meta, @Nullable List<Concept> children
     ) {
         this(conceptPath, name, display, dataset, description, allowFiltering, min, max, studyAcronym, meta, children, null, null);
     }
@@ -37,8 +37,8 @@ public record ContinuousConcept(
     }
 
     public ContinuousConcept(
-        String conceptPath, String name, String display, String dataset, String description, boolean allowFiltering, @Nullable Float min,
-        @Nullable Float max, String studyAcronym, Map<String, String> meta
+        String conceptPath, String name, String display, String dataset, String description, boolean allowFiltering, @Nullable Double min,
+        @Nullable Double max, String studyAcronym, Map<String, String> meta
     ) {
         this(conceptPath, name, display, dataset, description, allowFiltering, min, max, studyAcronym, meta, null);
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/JsonBlobParser.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/JsonBlobParser.java
@@ -9,7 +9,6 @@ import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -17,7 +16,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Component
 public class JsonBlobParser {
@@ -40,35 +38,35 @@ public class JsonBlobParser {
         }
     }
 
-    public Float parseMin(String valuesArr) {
+    public double parseMin(String valuesArr) {
         return parseFromIndex(valuesArr, 0);
     }
 
-    private Float parseFromIndex(String valuesArr, int index) {
+    protected double parseFromIndex(String valuesArr, int index) {
         try {
             JSONArray arr = new JSONArray(valuesArr);
             if (arr.length() != 2) {
-                return 0F;
+                return 0D;
             }
             Object raw = arr.get(index);
             return switch (raw) {
-                case Double d -> d.floatValue();
-                case Integer i -> i.floatValue();
-                case String s -> Double.valueOf(s).floatValue();
-                case BigDecimal d -> d.floatValue();
-                case BigInteger i -> i.floatValue();
-                default -> 0f;
+                case Double d -> d;
+                case Integer i -> i.doubleValue();
+                case BigDecimal d -> d.doubleValue();
+                case BigInteger i -> i.doubleValue();
+                case String s -> Double.parseDouble(s);
+                default -> 0D;
             };
         } catch (JSONException ex) {
             log.warn("Invalid json array for values: ", ex);
-            return 0F;
+            return 0D;
         } catch (NumberFormatException ex) {
             log.warn("Valid json array but invalid val within: ", ex);
-            return 0F;
+            return 0D;
         }
     }
 
-    public Float parseMax(String valuesArr) {
+    public double parseMax(String valuesArr) {
         return parseFromIndex(valuesArr, 1);
     }
 

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
@@ -37,7 +37,7 @@ class ConceptControllerTest {
         List<Concept> expected = List.of(
             new CategoricalConcept("/foo", "foo", "Foo", "my_dataset", "foo!", List.of(), true, "", null, Map.of()),
             new CategoricalConcept("/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of()),
-            new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of())
+            new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of())
         );
         Filter filter =
             new Filter(List.of(new Facet("questionare", "Questionare", "?", "Questionare", 1, null, "category", null)), "foo", List.of());
@@ -75,7 +75,7 @@ class ConceptControllerTest {
     void shouldGetConceptTree() {
         Concept fooBar =
             new CategoricalConcept("/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of());
-        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of());
+        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of());
         CategoricalConcept foo =
             new CategoricalConcept("/foo", "foo", "Foo", "my_dataset", "foo!", List.of(), true, "", List.of(fooBar, fooBaz), Map.of());
 
@@ -91,7 +91,7 @@ class ConceptControllerTest {
     void shouldGetNotConceptTreeForLargeDepth() {
         Concept fooBar =
             new CategoricalConcept("/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of());
-        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of());
+        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of());
         CategoricalConcept foo =
             new CategoricalConcept("/foo", "foo", "Foo", "my_dataset", "foo!", List.of(), true, "", List.of(fooBar, fooBaz), Map.of());
 
@@ -107,7 +107,7 @@ class ConceptControllerTest {
     void shouldGetNotConceptTreeForNegativeDepth() {
         Concept fooBar =
             new CategoricalConcept("/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of());
-        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of());
+        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of());
         CategoricalConcept foo =
             new CategoricalConcept("/foo", "foo", "Foo", "my_dataset", "foo!", List.of(), true, "", List.of(fooBar, fooBaz), Map.of());
         Mockito.when(conceptService.conceptTree("my_dataset", "/foo", -1)).thenReturn(Optional.of(foo));
@@ -122,7 +122,7 @@ class ConceptControllerTest {
     void shouldNotGetConceptTreeWhenConceptDNE() {
         Concept fooBar =
             new CategoricalConcept("/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of());
-        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of());
+        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of());
         CategoricalConcept foo =
             new CategoricalConcept("/foo", "foo", "Foo", "my_dataset", "foo!", List.of(), true, "", List.of(fooBar, fooBaz), Map.of());
 
@@ -138,7 +138,7 @@ class ConceptControllerTest {
         Concept fooBar = new CategoricalConcept(
             "/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of("key", "value")
         );
-        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of("key", "value"));
+        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of("key", "value"));
         List<Concept> concepts = List.of(fooBar, fooBaz);
         PageRequest page = PageRequest.of(0, 10);
         Mockito.when(conceptService.listDetailedConcepts(new Filter(List.of(), "", List.of()), page)).thenReturn(concepts);
@@ -154,7 +154,7 @@ class ConceptControllerTest {
         CategoricalConcept fooBar = new CategoricalConcept(
             "/foo//bar", "bar", "Bar", "my_dataset", "foo!", List.of("a", "b"), true, "", List.of(), Map.of("key", "value")
         );
-        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0F, 100F, "", Map.of("key", "value"));
+        Concept fooBaz = new ContinuousConcept("/foo//baz", "baz", "Baz", "my_dataset", "foo!", true, 0D, 100D, "", Map.of("key", "value"));
         List<Concept> concepts = List.of(fooBar, fooBaz);
         List<String> conceptPaths = List.of("/foo//bar", "/foo//bar");
         Mockito.when(conceptService.conceptsWithDetail(conceptPaths)).thenReturn(concepts);

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptRepositoryTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptRepositoryTest.java
@@ -85,15 +85,15 @@ class ConceptRepositoryTest {
         List<? extends Record> expected = List.of(
             new ContinuousConcept(
                 "\\phs000007\\pht000021\\phv00003844\\FL200\\", "phv00003844", "FL200", "phs000007",
-                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0F, 3F, "FHS", null
+                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0D, 3D, "FHS", null
             ),
             new ContinuousConcept(
                 "\\phs000007\\pht000022\\phv00004260\\FM219\\", "phv00004260", "FM219", "phs000007",
-                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0F, 1F, "FHS", null
+                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0D, 1D, "FHS", null
             ),
             new ContinuousConcept(
                 "\\phs000007\\pht000033\\phv00008849\\D080\\", "phv00008849", "D080", "phs000007", "# 12 OZ CUPS OF CAFFEINATED COLA/DAY",
-                true, 0F, 5F, "FHS", null
+                true, 0D, 5D, "FHS", null
             )
         );
 
@@ -106,15 +106,15 @@ class ConceptRepositoryTest {
         List<? extends Record> expected = List.of(
             new ContinuousConcept(
                 "\\phs000007\\pht000021\\phv00003844\\FL200\\", "phv00003844", "FL200", "phs000007",
-                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0F, 3F, "FHS", null
+                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0D, 3D, "FHS", null
             ),
             new ContinuousConcept(
                 "\\phs000007\\pht000022\\phv00004260\\FM219\\", "phv00004260", "FM219", "phs000007",
-                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0F, 1F, "FHS", null
+                "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", true, 0D, 1D, "FHS", null
             ),
             new ContinuousConcept(
                 "\\phs000007\\pht000033\\phv00008849\\D080\\", "phv00008849", "D080", "phs000007", "# 12 OZ CUPS OF CAFFEINATED COLA/DAY",
-                true, 0F, 5F, "FHS", null
+                true, 0D, 5D, "FHS", null
             )
         );
 
@@ -159,7 +159,7 @@ class ConceptRepositoryTest {
     void shouldGetDetailForConcept() {
         ContinuousConcept expected = new ContinuousConcept(
             "\\phs000007\\pht000033\\phv00008849\\D080\\", "phv00008849", "D080", "phs000007", "# 12 OZ CUPS OF CAFFEINATED COLA/DAY", true,
-            0F, 5F, "FHS", null
+            0D, 5D, "FHS", null
         );
         Optional<Concept> actual = subject.getConcept("phs000007", "\\phs000007\\pht000033\\phv00008849\\D080\\");
 
@@ -300,7 +300,7 @@ class ConceptRepositoryTest {
     void shouldGetStigmatizingConcept() {
         Optional<Concept> actual = subject.getConcept("phs002385", "\\phs002385\\TXNUM\\");
         ContinuousConcept expected = new ContinuousConcept(
-            "\\phs002385\\TXNUM\\", "TXNUM", "TXNUM", "phs002385", "Transplant Number", false, 0F, 0F, "HCT_for_SCD", Map.of()
+            "\\phs002385\\TXNUM\\", "TXNUM", "TXNUM", "phs002385", "Transplant Number", false, 0D, 0D, "HCT_for_SCD", Map.of()
         );
 
         Assertions.assertTrue(actual.isPresent());
@@ -316,8 +316,8 @@ class ConceptRepositoryTest {
 
         Assertions.assertTrue(actual.isPresent());
         ContinuousConcept concept = (ContinuousConcept) actual.get();
-        Assertions.assertEquals((float) min, concept.min());
-        Assertions.assertEquals((float) max, concept.max());
+        Assertions.assertEquals(min, concept.min());
+        Assertions.assertEquals(max, concept.max());
     }
 
     @Test
@@ -326,8 +326,8 @@ class ConceptRepositoryTest {
 
         Assertions.assertTrue(actual.isPresent());
         ContinuousConcept concept = (ContinuousConcept) actual.get();
-        Assertions.assertEquals(0.57f, concept.min());
-        Assertions.assertEquals(6.77f, concept.max());
+        Assertions.assertEquals(0.57D, concept.min());
+        Assertions.assertEquals(6.77D, concept.max());
     }
 
     @Test

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptServiceIntegrationTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptServiceIntegrationTest.java
@@ -54,7 +54,7 @@ class ConceptServiceIntegrationTest {
         );
         ContinuousConcept expected = new ContinuousConcept(
             "\\phs000007\\pht000021\\phv00003844\\FL200\\", "phv00003844", "FL200", "phs000007", "# 12 OZ CUPS OF CAFFEINATED COLA / DAY",
-            true, 0F, 3F, "FHS",
+            true, 0D, 3D, "FHS",
             Map.of(
                 "unique_identifier", "no", "stigmatizing", "no", "bdc_open_access", "yes", "values", "[0, 3]", "description",
                 "# 12 OZ CUPS OF CAFFEINATED COLA / DAY", "free_text", "no"

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptServiceTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptServiceTest.java
@@ -61,7 +61,7 @@ class ConceptServiceTest {
 
     @Test
     void shouldShowDetailForContinuous() {
-        ContinuousConcept concept = new ContinuousConcept("path", "", "", "dataset", null, true, 0F, 1F, "", null);
+        ContinuousConcept concept = new ContinuousConcept("path", "", "", "dataset", null, true, 0D, 1D, "", null);
         Map<String, String> meta = Map.of("MIN", "0", "MAX", "1", "stigmatizing", "true");
         Mockito.when(repository.getConcept("dataset", "path")).thenReturn(Optional.of(concept));
         Mockito.when(decoratorService.populateParentConcepts(Mockito.any())).thenAnswer(i -> i.getArguments()[0]);
@@ -94,7 +94,7 @@ class ConceptServiceTest {
         Map<String, String> metaA = Map.of("VALUES", "a", "stigmatizing", "true");
 
         ConceptShell shellB = new ConceptShell("pathB", "dataset");
-        ContinuousConcept conceptB = new ContinuousConcept("pathB", "", "", "dataset", null, true, 0F, 1F, "", null);
+        ContinuousConcept conceptB = new ContinuousConcept("pathB", "", "", "dataset", null, true, 0D, 1D, "", null);
         Map<String, String> metaB = Map.of("MIN", "0", "MAX", "1", "stigmatizing", "true");
 
         Map<Concept, Map<String, String>> metas = Map.of(shellA, metaA, shellB, metaB);

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/model/ConceptTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/model/ConceptTest.java
@@ -62,7 +62,7 @@ class ConceptTest {
             }
             """;
 
-        ContinuousConcept expected = new ContinuousConcept("/foo//baz", "baz", "Baz", "study_a", null, true, 0F, 1F, "", Map.of());
+        ContinuousConcept expected = new ContinuousConcept("/foo//baz", "baz", "Baz", "study_a", null, true, 0D, 1D, "", Map.of());
         Concept actual = new ObjectMapper().readValue(json, Concept.class);
 
         Assertions.assertEquals(expected, actual);
@@ -72,7 +72,7 @@ class ConceptTest {
     @Test
     void shouldIncludeTypeInList() throws JsonProcessingException {
         List<Record> concepts = List.of(
-            new ContinuousConcept("/foo//baz", "baz", "Baz", "study_a", null, true, 0F, 1F, "", Map.of()),
+            new ContinuousConcept("/foo//baz", "baz", "Baz", "study_a", null, true, 0D, 1D, "", Map.of()),
             new CategoricalConcept("/foo//bar", "bar", "Bar", "study_a", null, List.of("a", "b"), true, "", null, Map.of())
         );
 

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/util/JsonBlobParserTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/util/JsonBlobParserTest.java
@@ -1,0 +1,23 @@
+package edu.harvard.dbmi.avillach.dictionary.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class JsonBlobParserTest {
+
+    @Autowired
+    private JsonBlobParser jsonBlobParser;
+
+    @Test
+    void parseValues() {
+        Double v = jsonBlobParser.parseFromIndex("[-1.0,4.9E-324]", 1);
+        assertNotNull(v);
+        System.out.println(v);
+    }
+}


### PR DESCRIPTION
Replaced `Float` with `Double` in `ContinuousConcept` and related methods for better precision and consistency with data handling. Updated tests, models, and utilities accordingly to reflect this change.