### PR TITLE
[ALS-9500] Facet endpoint performance fix

### DIFF
--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
@@ -107,17 +107,11 @@ public class ConceptFilterQueryGenerator {
             FROM
                 concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                 LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
             WHERE
                 %s
                 %s
-                (
-                    continuous_min.value <> '' OR
-                    continuous_max.value <> '' OR
-                    categorical_values.value <> ''
-                )
+                categorical_values.value <> ''
             """
             .formatted(rankQuery, rankWhere, consentWhere);
     }
@@ -187,17 +181,11 @@ public class ConceptFilterQueryGenerator {
             FROM
                 concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                 LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
             WHERE
                 %s
                 %s
-                (
-                    continuous_min.value <> '' OR
-                    continuous_max.value <> '' OR
-                    categorical_values.value <> ''
-                )
+                categorical_values.value <> ''
             """
             .formatted(rankQuery, rankWhere, "");
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -98,17 +98,11 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                        LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                         LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
                     WHERE
                         (fc.name, facet.name) IN (:facets_in_cat_%s)
                         AND %s
-                        AND (
-                            continuous_min.value <> '' OR
-                            continuous_max.value <> '' OR
-                            categorical_values.value <> ''
-                        )
+                        AND categorical_values.value <> ''
                 )
                 """
                 .formatted(categoryKeys.get(category), categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
@@ -200,11 +194,7 @@ public class FacetQueryGenerator {
                         LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
                     WHERE
                         (fc.name, facet.name) IN (:facets_in_cat_%s)
-                        AND (
-                            continuous_min.value <> '' OR
-                            continuous_max.value <> '' OR
-                            categorical_values.value <> ''
-                        )
+                        AND categorical_values.value <> ''
                 )
                 """
                 .formatted(categoryKeys.get(category), categoryKeys.get(category));
@@ -300,11 +290,7 @@ public class FacetQueryGenerator {
                     %s
                     fc.name = :facet_category_name
                     AND %s
-                    AND (
-                        continuous_min.value <> '' OR
-                        continuous_max.value <> '' OR
-                        categorical_values.value <> ''
-                    )
+                    AND categorical_values.value <> ''
                 GROUP BY
                     facet.facet_id
                 ORDER BY
@@ -320,18 +306,12 @@ public class FacetQueryGenerator {
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                        LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                         LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
                     WHERE
                         fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                         AND %s
-                        AND (
-                            continuous_min.value <> '' OR
-                            continuous_max.value <> '' OR
-                            categorical_values.value <> ''
-                        )
+                        AND categorical_values.value <> ''
                 )
                 SELECT
                     facet.facet_id, count(*) as facet_count
@@ -370,17 +350,11 @@ public class FacetQueryGenerator {
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                    LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                    LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                     LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
                 WHERE
                     %s
                     fc.name = :facet_category_name
-                    AND (
-                        continuous_min.value <> '' OR
-                        continuous_max.value <> '' OR
-                        categorical_values.value <> ''
-                    )
+                    AND categorical_values.value <> ''
                 GROUP BY
                     facet.facet_id
                 ORDER BY
@@ -396,17 +370,11 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                        LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                         LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
                     WHERE
                         fc.name = :facet_category_name
                         AND facet.name IN (:facets)
-                        AND (
-                            continuous_min.value <> '' OR
-                            continuous_max.value <> '' OR
-                            categorical_values.value <> ''
-                        )
+                        AND categorical_values.value <> ''
                 )
                 SELECT
                     facet.facet_id, count(*) as facet_count
@@ -443,17 +411,11 @@ public class FacetQueryGenerator {
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                 JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                 LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
             WHERE
                 %s
                 %s
-                AND (
-                    continuous_min.value <> '' OR
-                    continuous_max.value <> '' OR
-                    categorical_values.value <> ''
-                )
+                AND categorical_values.value <> ''
             GROUP BY
                 facet.facet_id
             ORDER BY
@@ -475,16 +437,10 @@ public class FacetQueryGenerator {
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                 JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                LEFT JOIN concept_node_meta AS continuous_min ON concept_node.concept_node_id = continuous_min.concept_node_id AND continuous_min.KEY = 'min'
-                LEFT JOIN concept_node_meta AS continuous_max ON concept_node.concept_node_id = continuous_max.concept_node_id AND continuous_max.KEY = 'max'
                 LEFT JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values'
             WHERE
                 %s
-                (
-                    continuous_min.value <> '' OR
-                    continuous_max.value <> '' OR
-                    categorical_values.value <> ''
-                )
+                categorical_values.value <> ''
             GROUP BY
                 facet.facet_id
             ORDER BY

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGeneratorTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGeneratorTest.java
@@ -61,8 +61,8 @@ class FacetQueryGeneratorTest {
 
         List<IdCountPair> actual = template.query(query, params, new IdCountPairMapper());
         List<IdCountPair> expected = List.of(
-            new IdCountPair(22, 13), new IdCountPair(26, 3), new IdCountPair(31, 3), new IdCountPair(27, 3), new IdCountPair(28, 3),
-            new IdCountPair(23, 2), new IdCountPair(21, 2), new IdCountPair(25, 2), new IdCountPair(20, 1)
+            new IdCountPair(22, 13), new IdCountPair(26, 3), new IdCountPair(27, 3), new IdCountPair(28, 3), new IdCountPair(31, 3),
+            new IdCountPair(25, 2), new IdCountPair(21, 2), new IdCountPair(23, 2), new IdCountPair(20, 1)
         );
 
         Assertions.assertEquals(expected, actual);
@@ -147,8 +147,8 @@ class FacetQueryGeneratorTest {
 
         List<IdCountPair> actual = template.query(query, params, new IdCountPairMapper());
         List<IdCountPair> expected = List.of(
-            new IdCountPair(28, 3), new IdCountPair(26, 3), new IdCountPair(31, 3), new IdCountPair(22, 13), new IdCountPair(23, 2),
-            new IdCountPair(25, 2), new IdCountPair(27, 3)
+            new IdCountPair(22, 13), new IdCountPair(23, 2), new IdCountPair(25, 2), new IdCountPair(26, 3), new IdCountPair(27, 3),
+            new IdCountPair(28, 3), new IdCountPair(31, 3)
         );
 
         Assertions.assertEquals(expected, actual);

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepositoryTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepositoryTest.java
@@ -1,6 +1,5 @@
 package edu.harvard.dbmi.avillach.dictionary.facet;
 
-import edu.harvard.dbmi.avillach.dictionary.concept.ConceptRepository;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- On small servers, facet queries were taking > 20 secs
- Simplified exclusion logic: all facets, categorical and continous use the values meta to store their values, (min max or list)
- The min / max metas are not used
- Deleting those joins and comparisons got about a 10x perf boost