### PR TITLE
Sanitize and safeguard search input for TSQuery generation

### DIFF
--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/filter/FilterProcessor.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/filter/FilterProcessor.java
@@ -2,15 +2,20 @@ package edu.harvard.dbmi.avillach.dictionary.filter;
 
 import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * Preprocesses filter input before query generation. Sorts facets and consents for stable cache keys, and sanitizes the search string to
+ * prevent tsquery syntax errors from special characters.
+ */
 @Component
 public class FilterProcessor {
+
+    private static final int MAX_SEARCH_LENGTH = 200;
 
     public Filter processsFilter(Filter filter) {
         List<Facet> newFacets = filter.facets();
@@ -23,12 +28,22 @@ public class FilterProcessor {
             newConsents = new ArrayList<>(newConsents);
             newConsents.sort(Comparator.comparing(Function.identity()));
         }
-        filter = new Filter(newFacets, filter.search(), newConsents);
-
-        if (StringUtils.hasLength(filter.search())) {
-            filter = new Filter(filter.facets(), filter.search().replaceAll("_", "/"), filter.consents());
-        }
+        filter = new Filter(newFacets, sanitizeSearch(filter.search()), newConsents);
         return filter;
     }
 
+    /**
+     * Sanitizes a raw search string for safe use in PostgreSQL to_tsquery(). Strips all characters that are not Unicode letters, digits, or
+     * whitespace — this prevents tsquery operator injection (&amp;, |, !, :, *, etc.). Collapses runs of whitespace and trims. Returns
+     * empty string for input that contains only special characters (e.g. "&amp;"), which downstream code treats as no search.
+     */
+    static String sanitizeSearch(String search) {
+        if (search == null) {
+            return null;
+        }
+        if (search.length() > MAX_SEARCH_LENGTH) {
+            search = search.substring(0, MAX_SEARCH_LENGTH);
+        }
+        return search.replaceAll("[^\\p{L}\\p{N}\\s]", " ").replaceAll("\\s+", " ").trim();
+    }
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/QueryUtility.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/QueryUtility.java
@@ -22,8 +22,9 @@ public class QueryUtility {
         """;
 
     /**
-     * Converts a raw search string into a prefix-matching tsquery. Splits on whitespace, appends :* to each word, and ANDs them together.
-     * e.g. "ear infection" becomes to_tsquery('english', 'ear:* & infection:*')
+     * Converts a pre-sanitized search string into a prefix-matching tsquery. Input is sanitized by FilterProcessor.sanitizeSearch() before
+     * reaching SQL — only contains Unicode letters, digits, and single spaces. Splits on whitespace, appends :* to each word, and ANDs them
+     * together. e.g. "ear infection" becomes to_tsquery('english', 'ear:* & infection:*')
      */
     private static final String TSQUERY_EXPR = "to_tsquery('english', regexp_replace(trim(:search), '\\s+', ':* & ', 'g') || ':*')";
 
@@ -31,7 +32,7 @@ public class QueryUtility {
 
     /**
      * WHERE clause filter for full-text search. Uses the GIN-indexed searchable_fields tsvector column with prefix matching via to_tsquery.
-     * Expects a :search named parameter.
+     * Expects a :search named parameter that has been pre-sanitized by FilterProcessor.
      */
     public static final String SEARCH_WHERE = "concept_node.searchable_fields @@ " + TSQUERY_EXPR;
 }


### PR DESCRIPTION
### Summary of changes

- Added `sanitizeSearch()` method in `FilterProcessor` to preprocess and restrict search input, ensuring safer TSQuery generation.
- Enforced input constraints: Unicode letters, digits, spaces; capped input length at 200 characters.
- Updated `QueryUtility` documentation to outline the new pre-sanitization requirement.
- Improved JavaDoc comments for better clarity and completeness.

