### PR TITLE
Optimize query performance with parallel execution and indexing

### DIFF
--- a/db/dml/backfill_fcn_is_queryable.sql
+++ b/db/dml/backfill_fcn_is_queryable.sql
@@ -1,0 +1,28 @@
+-- Backfill/resync is_queryable on facet__concept_node from concept_node.
+--
+-- Run once after deploying V10__add_fcn_is_queryable.sql.
+-- Triggers maintain the column going forward:
+--   trg_set_fcn_is_queryable (BEFORE INSERT/UPDATE on fcn)
+--   trg_cascade_is_queryable_to_fcn (AFTER UPDATE OF is_queryable on concept_node)
+--
+-- Safe to re-run if facet__concept_node is truncated/reloaded.
+-- WHERE guard skips rows already correct, avoiding unnecessary writes.
+
+UPDATE dict.facet__concept_node fcn
+SET is_queryable = cn.is_queryable
+FROM dict.concept_node cn
+WHERE cn.concept_node_id = fcn.concept_node_id
+  AND fcn.is_queryable IS DISTINCT FROM cn.is_queryable;
+
+-- Verification: compare counts
+SELECT
+    COUNT(*) AS total_fcn,
+    COUNT(*) FILTER (WHERE is_queryable = TRUE) AS queryable,
+    COUNT(*) FILTER (WHERE is_queryable = FALSE) AS non_queryable
+FROM dict.facet__concept_node;
+
+-- Mismatch check: should return 0
+SELECT COUNT(*) AS mismatches
+FROM dict.facet__concept_node fcn
+JOIN dict.concept_node cn ON cn.concept_node_id = fcn.concept_node_id
+WHERE fcn.is_queryable IS DISTINCT FROM cn.is_queryable;

--- a/db/dml/backfill_is_queryable.sql
+++ b/db/dml/backfill_is_queryable.sql
@@ -1,0 +1,45 @@
+-- Backfill/resync is_queryable for all existing concept_node rows.
+--
+-- Run this once after deploying V7__add_queryable_column.sql and V8__add_is_queryable_trigger.sql.
+-- The trigger (trg_sync_is_queryable) maintains the column for all future ETL operations,
+-- but existing rows need a one-time update since the column was added with DEFAULT FALSE.
+--
+-- Safe to re-run if concept_node is truncated/reloaded, or if is_queryable needs resyncing.
+-- The WHERE guard skips rows already correct, avoiding unnecessary writes on large tables.
+--
+-- NOTE: uses value <> '' to match the trigger condition exactly (V8__add_is_queryable_trigger.sql).
+-- Expects the dict schema search_path to be set (or qualify as dict.concept_node below).
+
+UPDATE concept_node cn
+SET is_queryable = EXISTS (
+    SELECT 1
+    FROM concept_node_meta cnm
+    WHERE cnm.concept_node_id = cn.concept_node_id
+      AND cnm.key = 'values'
+      AND cnm.value <> ''
+)
+WHERE cn.is_queryable IS DISTINCT FROM EXISTS (
+    SELECT 1
+    FROM concept_node_meta cnm
+    WHERE cnm.concept_node_id = cn.concept_node_id
+      AND cnm.key = 'values'
+      AND cnm.value <> ''
+);
+
+-- Verification: compare counts
+SELECT
+    COUNT(*)                                     AS total_concepts,
+    COUNT(*) FILTER (WHERE is_queryable = TRUE)  AS queryable_concepts,
+    COUNT(*) FILTER (WHERE is_queryable = FALSE) AS non_queryable_concepts
+FROM concept_node;
+
+-- Mismatch check: should return 0
+SELECT COUNT(*) AS mismatches
+FROM concept_node cn
+WHERE cn.is_queryable IS DISTINCT FROM EXISTS (
+    SELECT 1
+    FROM concept_node_meta cnm
+    WHERE cnm.concept_node_id = cn.concept_node_id
+      AND cnm.key = 'values'
+      AND cnm.value <> ''
+);

--- a/db/dml/rebuild_searchable_fields.sql
+++ b/db/dml/rebuild_searchable_fields.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- rebuild_searchable_fields.sql
+--
+-- Standalone DML script that rebuilds the searchable_fields
+-- tsvector column on concept_node. This is the exact SQL that
+-- the dictionaryweights micro app generates from weights.csv.
+--
+-- Source of truth: dictionaryweights/weights.csv
+-- If weights.csv changes, this script must be regenerated.
+--
+-- Usage:
+--   psql -d dictionary -f rebuild_searchable_fields.sql
+--   (or run block-by-block in a SQL client)
+--
+-- Weight tiers (A = highest priority, D = lowest):
+--   A: concept_node.DISPLAY, concept_node.CONCEPT_PATH
+--   B: dataset.FULL_NAME, dataset.DESCRIPTION
+--   C: parent.DISPLAY, grandparent.DISPLAY
+--   D: concept_node_meta_str.values (whitelisted keys, values capped at 60K)
+--
+-- Uses 'english' language config to match query-layer
+-- to_tsquery('english', ...) stemming behavior.
+-- ============================================================
+
+UPDATE concept_node
+SET SEARCHABLE_FIELDS = data_table.search_vector
+FROM
+(
+    SELECT
+        setweight(to_tsvector('english', replace(coalesce(concept_node.DISPLAY, ''), '_', ' ')), 'A') ||
+        setweight(to_tsvector('english', replace(coalesce(concept_node.CONCEPT_PATH, ''), '_', ' ')), 'A') ||
+        setweight(to_tsvector('english', replace(coalesce(dataset.FULL_NAME, ''), '_', ' ')), 'B') ||
+        setweight(to_tsvector('english', replace(coalesce(dataset.DESCRIPTION, ''), '_', ' ')), 'B') ||
+        setweight(to_tsvector('english', replace(coalesce(parent.DISPLAY, ''), '_', ' ')), 'C') ||
+        setweight(to_tsvector('english', replace(coalesce(grandparent.DISPLAY, ''), '_', ' ')), 'C') ||
+        setweight(to_tsvector('english', replace(coalesce(concept_node_meta_str.values, ''), '_', ' ')), 'D')
+        AS search_vector,
+        concept_node.concept_node_id AS search_key
+    FROM
+        concept_node
+        LEFT JOIN
+        (
+            SELECT
+                concept_node_id AS id,
+                string_agg(DISTINCT safe_value, ' ') AS values
+            FROM (
+                SELECT concept_node_id, value AS safe_value
+                FROM concept_node_meta
+                WHERE value <> ''
+                  AND key IN ('description','derived_values','variable_type','comment','domain','Question','question','unit')
+                UNION ALL
+                SELECT concept_node_id, left(value, 60000) AS safe_value
+                FROM concept_node_meta
+                WHERE value <> '' AND key = 'values'
+            ) AS filtered_meta
+            GROUP BY
+                concept_node_id
+        ) AS concept_node_meta_str ON concept_node_meta_str.id = concept_node.concept_node_id
+        LEFT JOIN dataset AS study ON concept_node.dataset_id = study.dataset_id
+        LEFT JOIN concept_node AS parent ON concept_node.parent_id = parent.concept_node_id
+        LEFT JOIN concept_node AS grandparent ON parent.parent_id = grandparent.concept_node_id
+        LEFT JOIN (
+            SELECT
+                dataset_node.name AS NAME,
+                dataset_node.display AS FULL_NAME,
+                dataset_node.concept_path AS CONCEPT_PATH,
+                description_concept_node_meta.VALUE AS DESCRIPTION
+            FROM
+                concept_node AS dataset_node
+                JOIN concept_node_meta AS description_concept_node_meta ON description_concept_node_meta.KEY = 'description' AND description_concept_node_meta.concept_node_id = dataset_node.concept_node_id
+        ----------------------------------------------------------------------------------------------------
+        -- This join is saying "find me the concept node that shares the first two nodes of this concept
+        -- and then stops". So for /a/b/c/d/e/f/, it finds concept /a/b/
+        ----------------------------------------------------------------------------------------------------
+        ) AS dataset ON dataset.concept_path = REGEXP_REPLACE(concept_node.concept_path, '(^\\[^\\]*\\[^\\]*\\)(.*$)', '\1')
+) AS data_table
+WHERE concept_node.concept_node_id = data_table.search_key;

--- a/db/flyway/V10__add_fcn_is_queryable.sql
+++ b/db/flyway/V10__add_fcn_is_queryable.sql
@@ -1,0 +1,49 @@
+-- Add is_queryable column to facet__concept_node
+-- Eliminates the expensive concept_node JOIN from every facet query (~2100ms → ~800ms)
+-- Maintained by two triggers:
+--   1. trg_set_fcn_is_queryable: sets value on INSERT/UPDATE from concept_node
+--   2. trg_cascade_is_queryable_to_fcn: cascades concept_node.is_queryable changes
+
+ALTER TABLE dict.facet__concept_node
+    ADD COLUMN is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Trigger 1: set is_queryable on fcn INSERT/UPDATE (covers ETL reload)
+CREATE OR REPLACE FUNCTION dict.set_fcn_is_queryable() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.is_queryable := (
+        SELECT cn.is_queryable
+        FROM dict.concept_node cn
+        WHERE cn.concept_node_id = NEW.concept_node_id
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_set_fcn_is_queryable
+    BEFORE INSERT OR UPDATE ON dict.facet__concept_node
+    FOR EACH ROW EXECUTE FUNCTION dict.set_fcn_is_queryable();
+
+-- Trigger 2: cascade concept_node.is_queryable changes to fcn
+CREATE OR REPLACE FUNCTION dict.cascade_is_queryable_to_fcn() RETURNS TRIGGER AS $$
+BEGIN
+    IF OLD.is_queryable IS DISTINCT FROM NEW.is_queryable THEN
+        UPDATE dict.facet__concept_node
+        SET is_queryable = NEW.is_queryable
+        WHERE concept_node_id = NEW.concept_node_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_cascade_is_queryable_to_fcn
+    AFTER UPDATE OF is_queryable ON dict.concept_node
+    FOR EACH ROW EXECUTE FUNCTION dict.cascade_is_queryable_to_fcn();
+
+-- Partial indexes (equivalent to matview indexes from Step 17B)
+CREATE INDEX idx_fcn_queryable_fid_cid
+    ON dict.facet__concept_node(facet_id, concept_node_id)
+    WHERE is_queryable = TRUE;
+
+CREATE INDEX idx_fcn_queryable_cid
+    ON dict.facet__concept_node(concept_node_id)
+    WHERE is_queryable = TRUE;

--- a/db/flyway/V10__add_fcn_is_queryable.sql
+++ b/db/flyway/V10__add_fcn_is_queryable.sql
@@ -3,9 +3,18 @@
 -- Maintained by two triggers:
 --   1. trg_set_fcn_is_queryable: sets value on INSERT/UPDATE from concept_node
 --   2. trg_cascade_is_queryable_to_fcn: cascades concept_node.is_queryable changes
+--
+-- Uses unqualified table names so search_path resolves correctly in both
+-- production (currentSchema=dict) and test (public schema) environments.
 
-ALTER TABLE dict.facet__concept_node
-    ADD COLUMN is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE facet__concept_node
+    ADD COLUMN IF NOT EXISTS is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Backfill from concept_node.is_queryable (populated by V7)
+UPDATE facet__concept_node fcn
+SET is_queryable = cn.is_queryable
+FROM concept_node cn
+WHERE cn.concept_node_id = fcn.concept_node_id;
 
 -- Trigger 1: set is_queryable on fcn INSERT/UPDATE (covers ETL reload)
 CREATE OR REPLACE FUNCTION dict.set_fcn_is_queryable() RETURNS TRIGGER AS $$
@@ -19,8 +28,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trg_set_fcn_is_queryable ON facet__concept_node;
 CREATE TRIGGER trg_set_fcn_is_queryable
-    BEFORE INSERT OR UPDATE ON dict.facet__concept_node
+    BEFORE INSERT OR UPDATE ON facet__concept_node
     FOR EACH ROW EXECUTE FUNCTION dict.set_fcn_is_queryable();
 
 -- Trigger 2: cascade concept_node.is_queryable changes to fcn
@@ -35,15 +45,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trg_cascade_is_queryable_to_fcn ON concept_node;
 CREATE TRIGGER trg_cascade_is_queryable_to_fcn
-    AFTER UPDATE OF is_queryable ON dict.concept_node
+    AFTER UPDATE OF is_queryable ON concept_node
     FOR EACH ROW EXECUTE FUNCTION dict.cascade_is_queryable_to_fcn();
 
 -- Partial indexes (equivalent to matview indexes from Step 17B)
-CREATE INDEX idx_fcn_queryable_fid_cid
-    ON dict.facet__concept_node(facet_id, concept_node_id)
+CREATE INDEX IF NOT EXISTS idx_fcn_queryable_fid_cid
+    ON facet__concept_node(facet_id, concept_node_id)
     WHERE is_queryable = TRUE;
 
-CREATE INDEX idx_fcn_queryable_cid
-    ON dict.facet__concept_node(concept_node_id)
+CREATE INDEX IF NOT EXISTS idx_fcn_queryable_cid
+    ON facet__concept_node(concept_node_id)
     WHERE is_queryable = TRUE;

--- a/db/flyway/V10__add_fcn_is_queryable.sql
+++ b/db/flyway/V10__add_fcn_is_queryable.sql
@@ -3,9 +3,7 @@
 -- Maintained by two triggers:
 --   1. trg_set_fcn_is_queryable: sets value on INSERT/UPDATE from concept_node
 --   2. trg_cascade_is_queryable_to_fcn: cascades concept_node.is_queryable changes
---
--- Uses unqualified table names so search_path resolves correctly in both
--- production (currentSchema=dict) and test (public schema) environments.
+
 
 ALTER TABLE facet__concept_node
     ADD COLUMN IF NOT EXISTS is_queryable BOOLEAN NOT NULL DEFAULT FALSE;

--- a/db/flyway/V7__add_queryable_column.sql
+++ b/db/flyway/V7__add_queryable_column.sql
@@ -2,7 +2,7 @@
 -- Replaces the expensive JOIN concept_node_meta WHERE key='values' AND value<>''
 -- that was costing 932K index lookups per facet query.
 
-ALTER TABLE concept_node ADD COLUMN is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE concept_node ADD COLUMN IF NOT EXISTS is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
 
 UPDATE concept_node cn SET is_queryable = TRUE
 WHERE EXISTS (
@@ -11,6 +11,6 @@ WHERE EXISTS (
       AND cnm.key = 'values' AND cnm.value <> ''
 );
 
-CREATE INDEX idx_concept_node_queryable
+CREATE INDEX IF NOT EXISTS idx_concept_node_queryable
     ON concept_node (concept_node_id)
     WHERE is_queryable = TRUE;

--- a/db/flyway/V7__add_queryable_column.sql
+++ b/db/flyway/V7__add_queryable_column.sql
@@ -1,0 +1,16 @@
+-- Add is_queryable boolean to concept_node for fast displayability filtering.
+-- Replaces the expensive JOIN concept_node_meta WHERE key='values' AND value<>''
+-- that was costing 932K index lookups per facet query.
+
+ALTER TABLE concept_node ADD COLUMN is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE concept_node cn SET is_queryable = TRUE
+WHERE EXISTS (
+    SELECT 1 FROM concept_node_meta cnm
+    WHERE cnm.concept_node_id = cn.concept_node_id
+      AND cnm.key = 'values' AND cnm.value <> ''
+);
+
+CREATE INDEX idx_concept_node_queryable
+    ON concept_node (concept_node_id)
+    WHERE is_queryable = TRUE;

--- a/db/flyway/V8__add_is_queryable_trigger.sql
+++ b/db/flyway/V8__add_is_queryable_trigger.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION dict.sync_is_queryable() RETURNS TRIGGER AS $$
+DECLARE
+    target_id INT := coalesce(NEW.concept_node_id, OLD.concept_node_id);
+BEGIN
+    IF coalesce(NEW.key, OLD.key) = 'values' THEN
+        UPDATE dict.concept_node SET is_queryable = EXISTS (
+            SELECT 1 FROM dict.concept_node_meta
+            WHERE concept_node_id = target_id
+              AND key = 'values' AND value <> ''
+        )
+        WHERE concept_node_id = target_id;
+    END IF;
+    RETURN coalesce(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_is_queryable
+    AFTER INSERT OR UPDATE OR DELETE ON dict.concept_node_meta
+    FOR EACH ROW EXECUTE FUNCTION dict.sync_is_queryable();

--- a/db/flyway/V8__add_is_queryable_trigger.sql
+++ b/db/flyway/V8__add_is_queryable_trigger.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION dict.sync_is_queryable() RETURNS TRIGGER AS $$
 DECLARE
     target_id INT := coalesce(NEW.concept_node_id, OLD.concept_node_id);
 BEGIN
-    IF coalesce(NEW.key, OLD.key) = 'values' THEN
+    IF (NEW.key IS NOT NULL AND NEW.key = 'values') OR (OLD.key IS NOT NULL AND OLD.key = 'values') THEN
         UPDATE dict.concept_node SET is_queryable = EXISTS (
             SELECT 1 FROM dict.concept_node_meta
             WHERE concept_node_id = target_id

--- a/db/flyway/V9__add_fcn_concept_node_id_index.sql
+++ b/db/flyway/V9__add_fcn_concept_node_id_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_fcn_concept_node_id
+    ON dict.facet__concept_node(concept_node_id);

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/Weight.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/Weight.java
@@ -1,4 +1,13 @@
 package edu.harvard.dbmi.avillach.dictionaryweights;
 
+import java.util.Set;
+
 public record Weight(String key, String tier) {
+    private static final Set<String> VALID_TIERS = Set.of("A", "B", "C", "D");
+
+    public Weight {
+        if (tier == null || !VALID_TIERS.contains(tier)) {
+            throw new IllegalArgumentException("Tier must be one of: A, B, C, D");
+        }
+    }
 }

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/Weight.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/Weight.java
@@ -1,4 +1,4 @@
 package edu.harvard.dbmi.avillach.dictionaryweights;
 
-public record Weight(String key, int weight) {
+public record Weight(String key, String tier) {
 }

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreator.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreator.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 public class WeightUpdateCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(WeightUpdateCreator.class);
+    private static final Pattern SAFE_SQL_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_.()' ]*$");
 
     /**
      * Builds the UPDATE statement from the given weight configuration. Each weight entry
@@ -44,7 +46,12 @@ public class WeightUpdateCreator {
     public String createUpdate(List<Weight> weights) {
         LOG.info("Turning {} weights into a setweight query", weights.size());
         String searchVector = weights.stream()
-            .map(w -> "setweight(to_tsvector('english', replace(coalesce(%s, ''), '_', ' ')), '%s')".formatted(w.key(), w.tier()))
+            .map(w -> {
+                if (!SAFE_SQL_IDENTIFIER.matcher(w.key()).matches()) {
+                    throw new IllegalArgumentException("Unsafe SQL identifier in weight key: " + w.key());
+                }
+                return "setweight(to_tsvector('english', replace(coalesce(%s, ''), '_', ' ')), '%s')".formatted(w.key(), w.tier());
+            })
             .collect(Collectors.joining(" ||\n            "));
         return """
             UPDATE concept_node

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreator.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreator.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 public class WeightUpdateCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(WeightUpdateCreator.class);
-    private static final Pattern SAFE_SQL_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_.()' ]*$");
+    private static final Pattern SAFE_SQL_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_.]*$");
 
     /**
      * Builds the UPDATE statement from the given weight configuration. Each weight entry

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreator.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreator.java
@@ -6,14 +6,18 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
  * Generates the SQL UPDATE statement that populates the searchable_fields tsvector
- * column on concept_node. The tsvector is built from weighted fields (display name,
- * concept path, dataset info, parent/grandparent names) and a filtered subset of
- * concept_node_meta values.
+ * column on concept_node. Each field is wrapped in {@code setweight(to_tsvector(...), tier)}
+ * and concatenated with {@code ||} to produce a single weighted tsvector per concept.
+ *
+ * <p>Weight tiers (A/B/C/D) control ranking via {@code ts_rank}/{@code ts_rank_cd}:
+ * A = highest priority (display name, path), D = lowest (meta values).</p>
+ *
+ * <p>Underscores in field values are replaced with spaces before tsvector conversion
+ * so that terms like {@code pasc_pg2023} are tokenized as two independent terms
+ * ({@code pasc}, {@code pg2023}) rather than a single file-path token.</p>
  *
  * <p>Meta values are filtered to a whitelist of searchable keys (description, values,
  * derived_values, variable_type, comment, domain, question, unit) to avoid indexing
@@ -33,23 +37,23 @@ public class WeightUpdateCreator {
 
     /**
      * Builds the UPDATE statement from the given weight configuration. Each weight entry
-     * specifies a field name and a repeat count — higher weights mean the field's text
-     * appears more times in the concat, increasing its tsvector rank contribution.
+     * specifies a field name and a tier (A/B/C/D). The field is wrapped in
+     * {@code setweight(to_tsvector('english', replace(coalesce(FIELD, ''), '_', ' ')), 'TIER')}
+     * and all entries are joined with {@code ||}.
      */
     public String createUpdate(List<Weight> weights) {
-        LOG.info("Turning {} weights into a big concat query", weights.size());
-        String searchableFields = weights.stream()
-            .flatMap(this::expand)
-            .collect(Collectors.joining(", ' ',\n            "));
+        LOG.info("Turning {} weights into a setweight query", weights.size());
+        String searchVector = weights.stream()
+            .map(w -> "setweight(to_tsvector('english', replace(coalesce(%s, ''), '_', ' ')), '%s')".formatted(w.key(), w.tier()))
+            .collect(Collectors.joining(" ||\n            "));
         return """
             UPDATE concept_node
-            SET SEARCHABLE_FIELDS = to_tsvector('english', replace(data_table.search_str, '_', '/'))
+            SET SEARCHABLE_FIELDS = data_table.search_vector
             FROM
             (
                 SELECT
-                    concat(
-                        %s
-                    ) AS search_str,
+                    %s
+                    AS search_vector,
                     concept_node.concept_node_id AS search_key
                 FROM
                     concept_node
@@ -90,11 +94,6 @@ public class WeightUpdateCreator {
                     ) AS dataset ON dataset.concept_path = REGEXP_REPLACE(concept_node.concept_path, '(^\\\\[^\\\\]*\\\\[^\\\\]*\\\\)(.*$)', '\\1')
             ) AS data_table
             WHERE concept_node.concept_node_id = data_table.search_key;
-            """.formatted(searchableFields);
-    }
-
-    private Stream<String> expand(Weight weight) {
-        return IntStream.range(0, weight.weight()).boxed()
-            .map(i -> weight.key());
+            """.formatted(searchVector);
     }
 }

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightingParser.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightingParser.java
@@ -4,40 +4,35 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 @Service
 public class WeightingParser {
     private static final Logger LOG = LoggerFactory.getLogger(WeightingParser.class);
+    private static final Set<String> VALID_TIERS = Set.of("A", "B", "C", "D");
 
     public List<Weight> parseWeights(List<String> weights) {
         return weights.stream()
             .flatMap(this::parseWeight)
             .toList();
-
     }
 
     private Stream<Weight> parseWeight(String line) {
         String[] split = line.split(",");
         if (split.length != 2) {
-            LOG.warn("Failed to parse line {}, expected two column TSV", line);
+            LOG.warn("Failed to parse line {}, expected two column CSV", line);
             return Stream.empty();
         }
 
-        int weight;
-        try {
-            weight = Integer.parseInt(split[1]);
-        } catch (NumberFormatException ignored) {
-            LOG.warn("Failed to parse line {} because {} is not an int", line, split[1]);
+        String tier = split[1].trim().toUpperCase();
+        if (!VALID_TIERS.contains(tier)) {
+            LOG.warn("Failed to parse line {} because {} is not a valid tier (A/B/C/D)", line, split[1]);
             return Stream.empty();
         }
 
-        return Stream.of(new Weight(split[0], weight));
+        return Stream.of(new Weight(split[0], tier));
     }
 
 }

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightingParser.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightingParser.java
@@ -32,7 +32,7 @@ public class WeightingParser {
             return Stream.empty();
         }
 
-        return Stream.of(new Weight(split[0], tier));
+        return Stream.of(new Weight(split[0].trim(), tier));
     }
 
 }

--- a/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightingParser.java
+++ b/dictionaryweights/src/main/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightingParser.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -12,6 +13,7 @@ import java.util.stream.Stream;
 public class WeightingParser {
     private static final Logger LOG = LoggerFactory.getLogger(WeightingParser.class);
     private static final Set<String> VALID_TIERS = Set.of("A", "B", "C", "D");
+    private static final Map<String, String> NUMERIC_TIER_MAP = Map.of("1", "A", "2", "B", "3", "C", "4", "D");
 
     public List<Weight> parseWeights(List<String> weights) {
         return weights.stream()
@@ -26,9 +28,10 @@ public class WeightingParser {
             return Stream.empty();
         }
 
-        String tier = split[1].trim().toUpperCase();
+        String raw = split[1].trim().toUpperCase();
+        String tier = NUMERIC_TIER_MAP.getOrDefault(raw, raw);
         if (!VALID_TIERS.contains(tier)) {
-            LOG.warn("Failed to parse line {} because {} is not a valid tier (A/B/C/D)", line, split[1]);
+            LOG.warn("Failed to parse line {} because {} is not a valid tier (A/B/C/D)", line, raw);
             return Stream.empty();
         }
 

--- a/dictionaryweights/src/test/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreatorTest.java
+++ b/dictionaryweights/src/test/java/edu/harvard/dbmi/avillach/dictionaryweights/WeightUpdateCreatorTest.java
@@ -14,37 +14,26 @@ class WeightUpdateCreatorTest {
 
     @Test
     void shouldCreateQueryForWeights() {
-        List<Weight> weights = List.of(new Weight("TABLE_A.COLUMN", 2), new Weight("TABLE_B.COLUMN", 1));
+        List<Weight> weights = List.of(new Weight("TABLE_A.COLUMN", "A"), new Weight("TABLE_B.COLUMN", "B"));
 
         String actual = subject.createUpdate(weights);
-        String expected = """
-            UPDATE concept_node
-            SET SEARCHABLE_FIELDS = data_table.search_str
-            FROM
-            (
-                SELECT
-                    concat(
-                        TABLE_A.COLUMN, ' ',
-                        TABLE_A.COLUMN, ' ',
-                        TABLE_B.COLUMN
-                    ) AS search_str,
-                    concept_node.concept_node_id AS search_key
-                FROM
-                    concept_node
-                    LEFT JOIN
-                    (
-                        SELECT
-                            concept_node.concept_node_id AS id, string_agg(value, ' ') AS values
-                        FROM
-                            concept_node
-                            join concept_node_meta on concept_node.concept_node_id = concept_node_meta.concept_node_id
-                        GROUP BY
-                            concept_node.concept_node_id
-                    ) AS inner_q ON inner_q.id = concept_node.concept_node_id
-            ) AS data_table
-            WHERE concept_node.concept_node_id = data_table.search_key;
-            """;
 
-        Assertions.assertEquals(expected.trim(), actual.trim());
+        // Verify setweight structure with tier labels
+        Assertions.assertTrue(
+            actual.contains("setweight(to_tsvector('english', replace(coalesce(TABLE_A.COLUMN, ''), '_', ' ')), 'A')"),
+            "Should contain setweight for TABLE_A.COLUMN with tier A"
+        );
+        Assertions.assertTrue(
+            actual.contains("setweight(to_tsvector('english', replace(coalesce(TABLE_B.COLUMN, ''), '_', ' ')), 'B')"),
+            "Should contain setweight for TABLE_B.COLUMN with tier B"
+        );
+        // Verify fields are concatenated with ||
+        Assertions.assertTrue(actual.contains("||"), "Should concatenate tsvectors with ||");
+        // Verify underscore replacement uses space (not slash)
+        Assertions.assertTrue(actual.contains("'_', ' '"), "Should replace underscores with spaces");
+        Assertions.assertFalse(actual.contains("'_', '/'"), "Should not replace underscores with slashes");
+        // Verify output is a search_vector, not search_str
+        Assertions.assertTrue(actual.contains("AS search_vector"), "Should output as search_vector");
+        Assertions.assertFalse(actual.contains("concat("), "Should not use concat (old pattern)");
     }
 }

--- a/dictionaryweights/weights.csv
+++ b/dictionaryweights/weights.csv
@@ -1,7 +1,7 @@
-concept_node.DISPLAY,2
-concept_node.CONCEPT_PATH,2
-dataset.FULL_NAME,1
-dataset.DESCRIPTION,1
-parent.DISPLAY,1
-grandparent.DISPLAY,1
-concept_node_meta_str,1
+concept_node.DISPLAY,A
+concept_node.CONCEPT_PATH,A
+dataset.FULL_NAME,B
+dataset.DESCRIPTION,B
+parent.DISPLAY,C
+grandparent.DISPLAY,C
+concept_node_meta_str,D

--- a/dictionaryweights/weights.csv
+++ b/dictionaryweights/weights.csv
@@ -4,4 +4,4 @@ dataset.FULL_NAME,B
 dataset.DESCRIPTION,B
 parent.DISPLAY,C
 grandparent.DISPLAY,C
-concept_node_meta_str,D
+concept_node_meta_str.values,D

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -52,6 +52,9 @@ public class ConceptController {
             Future<List<Concept>> conceptsFuture = executor.submit(() -> conceptService.listConcepts(filter, pagination));
             count = countFuture.get();
             concepts = conceptsFuture.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Parallel concept query interrupted", e);
         } catch (Exception e) {
             throw new RuntimeException("Parallel concept query failed", e);
         }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -15,6 +15,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 @Controller
 public class ConceptController {
@@ -40,8 +43,20 @@ public class ConceptController {
         @RequestParam(name = "page_size", defaultValue = "10", required = false) int size
     ) {
         PageRequest pagination = PageRequest.of(page, size);
-        long count = conceptService.countConcepts(filter);
-        PageImpl<Concept> pageResp = new PageImpl<>(conceptService.listConcepts(filter, pagination), pagination, count);
+
+        // Run count and list in parallel — both are independent and cached separately
+        long count;
+        List<Concept> concepts;
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Long> countFuture = executor.submit(() -> conceptService.countConcepts(filter));
+            Future<List<Concept>> conceptsFuture = executor.submit(() -> conceptService.listConcepts(filter, pagination));
+            count = countFuture.get();
+            concepts = conceptsFuture.get();
+        } catch (Exception e) {
+            throw new RuntimeException("Parallel concept query failed", e);
+        }
+
+        PageImpl<Concept> pageResp = new PageImpl<>(concepts, pagination, count);
 
         AuditAttributes.putMetadata(httpRequest, "search_term", filter.search() != null ? filter.search() : "");
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
@@ -124,9 +124,9 @@ public class ConceptFilterQueryGenerator {
             FROM
                 concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
             WHERE
-                %s
+                concept_node.is_queryable = TRUE
+                AND %s
             """
             .formatted(rankQuery, whereClause);
     }
@@ -198,9 +198,9 @@ public class ConceptFilterQueryGenerator {
             FROM
                 concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
             WHERE
-                %s
+                concept_node.is_queryable = TRUE
+                AND %s
             """
             .formatted(rankQuery, whereClause);
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
@@ -92,7 +92,13 @@ public class ConceptFilterQueryGenerator {
         if (!CollectionUtils.isEmpty(filter.consents())) {
             params.addValue("consents", filter.consents());
         }
-        clauses.add(createValuelessNodeFilter(filter.search(), filter.consents()));
+        // Only add the base filter when it contributes conditions beyond is_queryable.
+        // For facet-only with no search and no consents, createFacetFilter already checks
+        // is_queryable = TRUE, so the INTERSECT with createValuelessNodeFilter (which just adds
+        // "WHERE is_queryable = TRUE AND TRUE") is redundant and prevents parallel execution.
+        if (StringUtils.hasLength(filter.search()) || !CollectionUtils.isEmpty(filter.consents()) || CollectionUtils.isEmpty(filter.facets())) {
+            clauses.add(createValuelessNodeFilter(filter.search(), filter.consents()));
+        }
         String superQuery = getSuperQuery(pageable, clauses, params);
 
         return new QueryParamPair(superQuery, params);
@@ -161,7 +167,8 @@ public class ConceptFilterQueryGenerator {
                         JOIN concept_node ON concept_node.concept_node_id = facet__concept_node.concept_node_id
                         LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                     WHERE
-                        %s
+                        concept_node.is_queryable = TRUE
+                        AND %s
                         %s
                         facet.name IN (:facets_for_category_%s ) AND facet_category.name = :category_%s
                     GROUP BY
@@ -169,6 +176,72 @@ public class ConceptFilterQueryGenerator {
                 )
                 """.formatted(rankQuery, rankWhere, consentWhere, facetsForCategory.getKey(), facetsForCategory.getKey());
         }).toList();
+    }
+
+    /**
+     * Generates an optimized count query that avoids the CTE/ranking/allow_filtering overhead
+     * of {@link #generateFilterQuery}. Uses EXISTS with concept_node as the driving table,
+     * which enables parallel execution and leverages idx_fcn_concept_node_id.
+     */
+    public QueryParamPair generateCountQuery(Filter filter) {
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        String searchCondition = "";
+        if (StringUtils.hasLength(filter.search())) {
+            params.addValue("search", filter.search().trim());
+            searchCondition = " AND " + QueryUtility.SEARCH_WHERE;
+        }
+        String consentCondition = "";
+        if (!CollectionUtils.isEmpty(filter.consents())) {
+            params.addValue("consents", filter.consents());
+            consentCondition = " AND " + CONSENT_QUERY.strip().replaceAll("\\s+AND\\s*$", "");
+        }
+
+        if (CollectionUtils.isEmpty(filter.facets())) {
+            // No facets: count all queryable concepts matching search/consents
+            String sql = """
+                SELECT count(*)
+                FROM concept_node
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
+                WHERE concept_node.is_queryable = TRUE
+                %s
+                %s
+                """.formatted(searchCondition, consentCondition);
+            return new QueryParamPair(sql, params);
+        }
+
+        // Group facets by category — each category produces an EXISTS clause
+        var grouped = filter.facets().stream().collect(Collectors.groupingBy(Facet::category));
+
+        List<String> existsClauses = grouped.entrySet().stream().map(entry -> {
+            String categoryKey = entry.getKey();
+            params.addValue("facets_for_category_%s".formatted(categoryKey),
+                entry.getValue().stream().map(Facet::name).toList());
+            params.addValue("category_%s".formatted(categoryKey), categoryKey);
+            return """
+                EXISTS (
+                    SELECT 1 FROM facet__concept_node fcn_%1$s
+                    WHERE fcn_%1$s.concept_node_id = cn.concept_node_id
+                      AND fcn_%1$s.facet_id IN (
+                        SELECT f.facet_id FROM facet f
+                        JOIN facet_category fc ON fc.facet_category_id = f.facet_category_id
+                        WHERE f.name IN (:facets_for_category_%1$s) AND fc.name = :category_%1$s
+                      )
+                )
+                """.formatted(categoryKey);
+        }).toList();
+
+        String existsWhere = String.join(" AND ", existsClauses);
+
+        String sql = """
+            SELECT count(*)
+            FROM concept_node cn
+            LEFT JOIN dataset ON cn.dataset_id = dataset.dataset_id
+            WHERE cn.is_queryable = TRUE
+            AND %s
+            %s
+            %s
+            """.formatted(existsWhere, searchCondition.replace("concept_node.", "cn."), consentCondition);
+        return new QueryParamPair(sql, params);
     }
 
     public QueryParamPair generateLegacyFilterQuery(Filter filter, Pageable pageable) {

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
@@ -96,7 +96,10 @@ public class ConceptFilterQueryGenerator {
         // For facet-only with no search and no consents, createFacetFilter already checks
         // is_queryable = TRUE, so the INTERSECT with createValuelessNodeFilter (which just adds
         // "WHERE is_queryable = TRUE AND TRUE") is redundant and prevents parallel execution.
-        if (StringUtils.hasLength(filter.search()) || !CollectionUtils.isEmpty(filter.consents()) || CollectionUtils.isEmpty(filter.facets())) {
+        if (
+            StringUtils.hasLength(filter.search()) || !CollectionUtils.isEmpty(filter.consents())
+                || CollectionUtils.isEmpty(filter.facets())
+        ) {
             clauses.add(createValuelessNodeFilter(filter.search(), filter.consents()));
         }
         String superQuery = getSuperQuery(pageable, clauses, params);
@@ -133,8 +136,7 @@ public class ConceptFilterQueryGenerator {
             WHERE
                 concept_node.is_queryable = TRUE
                 AND %s
-            """
-            .formatted(rankQuery, whereClause);
+            """.formatted(rankQuery, whereClause);
     }
 
     /**
@@ -179,9 +181,8 @@ public class ConceptFilterQueryGenerator {
     }
 
     /**
-     * Generates an optimized count query that avoids the CTE/ranking/allow_filtering overhead
-     * of {@link #generateFilterQuery}. Uses EXISTS with concept_node as the driving table,
-     * which enables parallel execution and leverages idx_fcn_concept_node_id.
+     * Generates an optimized count query that avoids the CTE/ranking/allow_filtering overhead of {@link #generateFilterQuery}. Uses EXISTS
+     * with concept_node as the driving table, which enables parallel execution and leverages idx_fcn_concept_node_id.
      */
     public QueryParamPair generateCountQuery(Filter filter) {
         MapSqlParameterSource params = new MapSqlParameterSource();
@@ -214,8 +215,7 @@ public class ConceptFilterQueryGenerator {
 
         List<String> existsClauses = grouped.entrySet().stream().map(entry -> {
             String categoryKey = entry.getKey();
-            params.addValue("facets_for_category_%s".formatted(categoryKey),
-                entry.getValue().stream().map(Facet::name).toList());
+            params.addValue("facets_for_category_%s".formatted(categoryKey), entry.getValue().stream().map(Facet::name).toList());
             params.addValue("category_%s".formatted(categoryKey), categoryKey);
             return """
                 EXISTS (
@@ -261,7 +261,7 @@ public class ConceptFilterQueryGenerator {
         String rankQuery = "0 as rank";
         String whereClause = "TRUE";
         if (StringUtils.hasLength(search)) {
-            rankQuery = "ts_rank(searchable_fields, to_tsquery(:dynamic_tsquery)) AS rank";
+            rankQuery = "ts_rank_cd(searchable_fields, to_tsquery(:dynamic_tsquery)) AS rank";
             whereClause = "concept_node.searchable_fields @@ to_tsquery(:dynamic_tsquery)";
         }
         return """
@@ -274,8 +274,7 @@ public class ConceptFilterQueryGenerator {
             WHERE
                 concept_node.is_queryable = TRUE
                 AND %s
-            """
-            .formatted(rankQuery, whereClause);
+            """.formatted(rankQuery, whereClause);
     }
 
     /**

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptFilterQueryGenerator.java
@@ -4,6 +4,7 @@ import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import edu.harvard.dbmi.avillach.dictionary.filter.QueryParamPair;
 import edu.harvard.dbmi.avillach.dictionary.util.QueryUtility;
+import edu.harvard.dbmi.avillach.dictionary.util.SchemaDetector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 @Component
 public class ConceptFilterQueryGenerator {
     private final List<String> disallowedMetaFields;
+    private final SchemaDetector schemaDetector;
 
     /**
      * CTE fragment that computes a rank adjustment multiplier per concept. Concepts flagged with disallowed meta keys (e.g.
@@ -66,8 +68,11 @@ public class ConceptFilterQueryGenerator {
         """;
 
     @Autowired
-    public ConceptFilterQueryGenerator(@Value("${filtering.unfilterable_concepts}") List<String> disallowedMetaFields) {
+    public ConceptFilterQueryGenerator(
+        @Value("${filtering.unfilterable_concepts}") List<String> disallowedMetaFields, SchemaDetector schemaDetector
+    ) {
         this.disallowedMetaFields = disallowedMetaFields;
+        this.schemaDetector = schemaDetector;
     }
 
     /**
@@ -134,9 +139,9 @@ public class ConceptFilterQueryGenerator {
                 concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
             WHERE
-                concept_node.is_queryable = TRUE
+                %s
                 AND %s
-            """.formatted(rankQuery, whereClause);
+            """.formatted(rankQuery, schemaDetector.conceptNodeQueryableClause("concept_node"), whereClause);
     }
 
     /**
@@ -169,14 +174,17 @@ public class ConceptFilterQueryGenerator {
                         JOIN concept_node ON concept_node.concept_node_id = facet__concept_node.concept_node_id
                         LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                     WHERE
-                        concept_node.is_queryable = TRUE
+                        %s
                         AND %s
                         %s
                         facet.name IN (:facets_for_category_%s ) AND facet_category.name = :category_%s
                     GROUP BY
                         facet__concept_node.concept_node_id
                 )
-                """.formatted(rankQuery, rankWhere, consentWhere, facetsForCategory.getKey(), facetsForCategory.getKey());
+                """.formatted(
+                rankQuery, schemaDetector.conceptNodeQueryableClause("concept_node"), rankWhere, consentWhere, facetsForCategory.getKey(),
+                facetsForCategory.getKey()
+            );
         }).toList();
     }
 
@@ -203,10 +211,10 @@ public class ConceptFilterQueryGenerator {
                 SELECT count(*)
                 FROM concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                WHERE concept_node.is_queryable = TRUE
+                WHERE %s
                 %s
                 %s
-                """.formatted(searchCondition, consentCondition);
+                """.formatted(schemaDetector.conceptNodeQueryableClause("concept_node"), searchCondition, consentCondition);
             return new QueryParamPair(sql, params);
         }
 
@@ -236,11 +244,13 @@ public class ConceptFilterQueryGenerator {
             SELECT count(*)
             FROM concept_node cn
             LEFT JOIN dataset ON cn.dataset_id = dataset.dataset_id
-            WHERE cn.is_queryable = TRUE
+            WHERE %s
             AND %s
             %s
             %s
-            """.formatted(existsWhere, searchCondition.replace("concept_node.", "cn."), consentCondition);
+            """.formatted(
+            schemaDetector.conceptNodeQueryableClause("cn"), existsWhere, searchCondition.replace("concept_node.", "cn."), consentCondition
+        );
         return new QueryParamPair(sql, params);
     }
 
@@ -272,9 +282,9 @@ public class ConceptFilterQueryGenerator {
                 concept_node
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
             WHERE
-                concept_node.is_queryable = TRUE
+                %s
                 AND %s
-            """.formatted(rankQuery, whereClause);
+            """.formatted(rankQuery, schemaDetector.conceptNodeQueryableClause("concept_node"), whereClause);
     }
 
     /**

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptRepository.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -51,7 +52,9 @@ public class ConceptRepository {
     }
 
 
+    @Transactional(readOnly = true)
     public List<Concept> getConcepts(Filter filter, Pageable pageable) {
+        template.getJdbcTemplate().execute("SET LOCAL work_mem = '64MB'");
         QueryParamPair filterQ = filterGen.generateFilterQuery(filter, pageable);
         String sql = QueryUtility.ALLOW_FILTERING_Q + ", " + filterQ.query()
             + """
@@ -80,10 +83,11 @@ public class ConceptRepository {
         return template.query(sql, params, mapper);
     }
 
+    @Transactional(readOnly = true)
     public long countConcepts(Filter filter) {
-        QueryParamPair pair = filterGen.generateFilterQuery(filter, Pageable.unpaged());
-        String sql = "WITH " + pair.query() + " SELECT count(*) FROM concepts_filtered_sorted;";
-        Long count = template.queryForObject(sql, pair.params(), Long.class);
+        template.getJdbcTemplate().execute("SET LOCAL work_mem = '64MB'");
+        QueryParamPair pair = filterGen.generateCountQuery(filter);
+        Long count = template.queryForObject(pair.query(), pair.params(), Long.class);
         return count == null ? 0 : count;
     }
 

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import edu.harvard.dbmi.avillach.dictionary.filter.QueryParamPair;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +72,98 @@ public class FacetQueryGenerator {
                 return createMultiCategorySQLNoSearch(groupedFacets, consentWhere, params);
             }
         }
+    }
+
+    /**
+     * Returns independent count queries for multi-category facet requests, one per UNION block.
+     * Each query includes the shared CTEs and can be executed in parallel.
+     * Returns (facet_name, category_name, facet_count) rows for merging in Java.
+     */
+    public List<QueryParamPair> createMultiCategoryCountBlocks(Filter filter) {
+        Map<String, List<Facet>> groupedFacets =
+            (filter.facets() == null ? Stream.<Facet>of() : filter.facets().stream()).collect(Collectors.groupingBy(Facet::category));
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        String consentWhere = "";
+        String consentJoins = "";
+        if (!CollectionUtils.isEmpty(filter.consents())) {
+            params.addValue("consents", filter.consents());
+            consentWhere = CONSENT_QUERY;
+            consentJoins = """
+                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""";
+        }
+
+        Map<String, String> categoryKeys = createSQLSafeCategoryKeys(groupedFacets.keySet().stream().toList());
+        boolean hasSearch = StringUtils.hasLength(filter.search());
+        if (hasSearch) {
+            params.addValue("search", filter.search());
+        }
+
+        // Build shared CTEs (same as existing multi-category methods)
+        String conceptsQuery = groupedFacets.keySet().stream().map(category -> {
+            List<String[]> selectedFacetsInCategory = groupedFacets.entrySet().stream().filter(e -> category.equals(e.getKey()))
+                .flatMap(e -> e.getValue().stream()).map(facet -> new String[] {facet.category(), facet.name()}).toList();
+            params.addValue("facets_in_cat_" + categoryKeys.get(category), selectedFacetsInCategory);
+            params.addValue("facet_category_" + categoryKeys.get(category), category);
+            String searchJoin = hasSearch ? "JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id" : "";
+            String searchWhere = hasSearch ? "AND " + QueryUtility.SEARCH_WHERE : "";
+            return """
+                facet_category_%s_concepts AS (
+                    SELECT DISTINCT(fcn.concept_node_id) as concept_node_id
+                    FROM facet
+                        JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
+                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
+                        %s
+                    WHERE fcn.is_queryable = TRUE
+                        AND (fc.name, facet.name) IN (:facets_in_cat_%s)
+                        %s
+                )""".formatted(categoryKeys.get(category), searchJoin, categoryKeys.get(category), searchWhere);
+        }).collect(Collectors.joining(",\n"));
+        String ctePrefix = "WITH " + conceptsQuery + "\n";
+
+        List<QueryParamPair> blocks = new ArrayList<>();
+
+        // One block per selected category: filtered by OTHER categories' concepts
+        for (String category : groupedFacets.keySet()) {
+            String existsChain = categoryKeys.values().stream()
+                .filter(key -> !categoryKeys.get(category).equals(key))
+                .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
+                .collect(Collectors.joining("\n                AND "));
+            String block = ctePrefix + """
+                SELECT facet.name AS facet_name, fc.name AS category_name, count(*) AS facet_count
+                FROM facet
+                    JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
+                    JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
+                    %s
+                WHERE fcn.is_queryable = TRUE
+                    AND %s
+                    %s
+                    AND fc.name = :facet_category_%s
+                GROUP BY facet.name, fc.name
+                """.formatted(consentJoins, consentWhere, existsChain, categoryKeys.get(category));
+            blocks.add(new QueryParamPair(block, params));
+        }
+
+        // One block for unselected categories: filtered by ALL categories' concepts
+        params.addValue("all_selected_facet_categories", groupedFacets.keySet());
+        String existsChainAll = categoryKeys.values().stream()
+            .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
+            .collect(Collectors.joining("\n                AND "));
+        String unselectedBlock = ctePrefix + """
+            SELECT facet.name AS facet_name, fc.name AS category_name, count(*) AS facet_count
+            FROM facet
+                JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
+                JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
+                %s
+            WHERE fcn.is_queryable = TRUE
+                AND %s
+                fc.name NOT IN (:all_selected_facet_categories)
+                AND %s
+            GROUP BY facet.name, fc.name
+            """.formatted(consentJoins, consentWhere, existsChainAll);
+        blocks.add(new QueryParamPair(unselectedBlock, params));
+
+        return blocks;
     }
 
     private Map<String, String> createSQLSafeCategoryKeys(List<String> categories) {

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -75,9 +75,8 @@ public class FacetQueryGenerator {
     }
 
     /**
-     * Returns independent count queries for multi-category facet requests, one per UNION block.
-     * Each query includes the shared CTEs and can be executed in parallel.
-     * Returns (facet_name, category_name, facet_count) rows for merging in Java.
+     * Returns independent count queries for multi-category facet requests, one per UNION block. Each query includes the shared CTEs and can
+     * be executed in parallel. Returns (facet_name, category_name, facet_count) rows for merging in Java.
      */
     public List<QueryParamPair> createMultiCategoryCountBlocks(Filter filter) {
         Map<String, List<Facet>> groupedFacets =
@@ -125,8 +124,7 @@ public class FacetQueryGenerator {
 
         // One block per selected category: filtered by OTHER categories' concepts
         for (String category : groupedFacets.keySet()) {
-            String existsChain = categoryKeys.values().stream()
-                .filter(key -> !categoryKeys.get(category).equals(key))
+            String existsChain = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
                 .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
                 .collect(Collectors.joining("\n                AND "));
             String block = ctePrefix + """
@@ -179,11 +177,9 @@ public class FacetQueryGenerator {
     ) {
         Map<String, String> categoryKeys = createSQLSafeCategoryKeys(facets.keySet().stream().toList());
         params.addValue("search", search);
-        String consentJoins = StringUtils.hasLength(consentWhere)
-            ? """
-                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
-            : "";
+        String consentJoins = StringUtils.hasLength(consentWhere) ? """
+            LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+            LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
 
         /*
          * For each category of facet present in the filter, create a query that represents all the concept IDs associated with the selected
@@ -208,8 +204,7 @@ public class FacetQueryGenerator {
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                         AND %s
                 )
-                """
-                .formatted(categoryKeys.get(category), categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
+                """.formatted(categoryKeys.get(category), categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
         }).collect(Collectors.joining(",\n"));
         /*
          * Categories with no selected facets contribute no concepts, so ignore them for now. Now, for each category with selected facets,
@@ -276,11 +271,9 @@ public class FacetQueryGenerator {
 
     private String createMultiCategorySQLNoSearch(Map<String, List<Facet>> facets, String consentWhere, MapSqlParameterSource params) {
         Map<String, String> categoryKeys = createSQLSafeCategoryKeys(facets.keySet().stream().toList());
-        String consentJoins = StringUtils.hasLength(consentWhere)
-            ? """
-                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
-            : "";
+        String consentJoins = StringUtils.hasLength(consentWhere) ? """
+            LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+            LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
 
         /*
          * For each category of facet present in the filter, create a query that represents all the concept IDs associated with the selected
@@ -303,8 +296,7 @@ public class FacetQueryGenerator {
                         fcn.is_queryable = TRUE
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                 )
-                """
-                .formatted(categoryKeys.get(category), categoryKeys.get(category));
+                """.formatted(categoryKeys.get(category), categoryKeys.get(category));
         }).collect(Collectors.joining(",\n"));
         /*
          * Now, for each category with selected facets, take all the concepts from all other categories with selections and INTERSECT them.
@@ -374,11 +366,9 @@ public class FacetQueryGenerator {
         params.addValue("facet_category_name", facets.getFirst().category());
         params.addValue("facets", facets.stream().map(Facet::name).toList());
         params.addValue("search", search);
-        String consentJoins = StringUtils.hasLength(consentWhere)
-            ? """
-                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
-            : "";
+        String consentJoins = StringUtils.hasLength(consentWhere) ? """
+            LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+            LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
         // Part 1: facets in the matched category that are displayable + match search
         // Part 2: facets from other categories for concepts matching selected facets + search
         return """
@@ -434,18 +424,15 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """
-            .formatted(consentWhere, QueryUtility.SEARCH_WHERE, QueryUtility.SEARCH_WHERE, consentJoins, consentWhere);
+            """.formatted(consentWhere, QueryUtility.SEARCH_WHERE, QueryUtility.SEARCH_WHERE, consentJoins, consentWhere);
     }
 
     private String createSingleCategorySQLNoSearch(List<Facet> facets, String consentWhere, MapSqlParameterSource params) {
         params.addValue("facet_category_name", facets.getFirst().category());
         params.addValue("facets", facets.stream().map(Facet::name).toList());
-        String consentJoins = StringUtils.hasLength(consentWhere)
-            ? """
-                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
-            : "";
+        String consentJoins = StringUtils.hasLength(consentWhere) ? """
+            LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+            LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
         // return all the facets in the matched category that are displayable
         // UNION
         // all the facets from other categories that match concepts that match selected facets from this category
@@ -498,8 +485,7 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """
-            .formatted(consentJoins, consentWhere, consentJoins, consentWhere);
+            """.formatted(consentJoins, consentWhere, consentJoins, consentWhere);
     }
 
     private String createNoFacetSQLWithSearch(String search, String consentWhere, MapSqlParameterSource params) {
@@ -507,9 +493,7 @@ public class FacetQueryGenerator {
         // match search
         // are displayable
         params.addValue("search", search);
-        String datasetJoin = StringUtils.hasLength(consentWhere)
-            ? "LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"
-            : "";
+        String datasetJoin = StringUtils.hasLength(consentWhere) ? "LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id" : "";
         return """
             SELECT
                 facet.facet_id, count(*) as facet_count
@@ -527,17 +511,14 @@ public class FacetQueryGenerator {
                 facet.facet_id
             ORDER BY
                 facet_count DESC
-            """
-            .formatted(datasetJoin, consentWhere, QueryUtility.SEARCH_WHERE);
+            """.formatted(datasetJoin, consentWhere, QueryUtility.SEARCH_WHERE);
 
     }
 
     private String createNoFacetSQLNoSearch(MapSqlParameterSource params, String consents) {
-        String consentJoins = StringUtils.hasLength(consents)
-            ? """
-                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
-            : "";
+        String consentJoins = StringUtils.hasLength(consents) ? """
+            LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+            LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
         String whereClause = StringUtils.hasLength(consents) ? consents.strip().replaceAll("\\s+AND\\s*$", "") : "TRUE";
         return """
             SELECT
@@ -554,7 +535,6 @@ public class FacetQueryGenerator {
                 facet.facet_id
             ORDER BY
                 facet_count DESC
-            """
-            .formatted(consentJoins, whereClause);
+            """.formatted(consentJoins, whereClause);
     }
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -116,8 +116,9 @@ public class FacetQueryGenerator {
          * take all the concepts from all other categories with selections and INTERSECT them. This creates the concepts for this category
          */
         String selectedFacetsQuery = facets.keySet().stream().map(category -> {
-            String allConceptsForCategory = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
-                .map(key -> "SELECT * FROM facet_category_" + key + "_concepts").collect(Collectors.joining(" INTERSECT "));
+            String existsChain = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
+                .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
+                .collect(Collectors.joining("\n                    AND "));
             params.addValue("", "");
             return """
                 (
@@ -131,22 +132,23 @@ public class FacetQueryGenerator {
                         LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                     WHERE
                         %s
-                        fcn.concept_node_id IN (%s) AND
-                        fc.name = :facet_category_%s
+                        %s
+                        AND fc.name = :facet_category_%s
                     GROUP BY
                         facet.facet_id
                     ORDER BY
                         facet_count DESC
                 )
-                """.formatted(consentWhere, allConceptsForCategory, categoryKeys.get(category));
+                """.formatted(consentWhere, existsChain, categoryKeys.get(category));
         }).collect(Collectors.joining("\n\tUNION\n"));
 
         /*
          * For categories with no selected facets, take all the concepts from all facets, and use them for the counts
          */
         params.addValue("all_selected_facet_categories", facets.keySet());
-        String allConceptsForUnselectedCategories = categoryKeys.values().stream()
-            .map(key -> "SELECT * FROM facet_category_" + key + "_concepts").collect(Collectors.joining(" INTERSECT "));
+        String existsChainAll = categoryKeys.values().stream()
+            .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
+            .collect(Collectors.joining("\n                    AND "));
         String unselectedFacetsQuery = """
             UNION
             (
@@ -161,13 +163,13 @@ public class FacetQueryGenerator {
                 WHERE
                     %s
                     fc.name NOT IN (:all_selected_facet_categories)
-                    AND fcn.concept_node_id IN (%s)
+                    AND %s
                 GROUP BY
                     facet.facet_id
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentWhere, allConceptsForUnselectedCategories);
+            """.formatted(consentWhere, existsChainAll);
 
         return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
     }
@@ -206,8 +208,9 @@ public class FacetQueryGenerator {
          */
         String selectedFacetsQuery = facets.keySet().stream().map(category -> {
             params.addValue("facet_category_" + categoryKeys.get(category), category);
-            String allConceptsForCategory = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
-                .map(key -> "SELECT * FROM facet_category_" + key + "_concepts").collect(Collectors.joining(" INTERSECT "));
+            String existsChain = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
+                .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
+                .collect(Collectors.joining("\n                    AND "));
             params.addValue("", "");
             return """
                 (
@@ -221,22 +224,23 @@ public class FacetQueryGenerator {
                         LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                     WHERE
                         %s
-                        fcn.concept_node_id IN (%s)
+                        %s
                         AND fc.name = :facet_category_%s
                     GROUP BY
                         facet.facet_id
                     ORDER BY
                         facet_count DESC
                 )
-                """.formatted(consentWhere, allConceptsForCategory, categoryKeys.get(category));
+                """.formatted(consentWhere, existsChain, categoryKeys.get(category));
         }).collect(Collectors.joining("\n\tUNION\n"));
 
         /*
          * For categories with no selected facets, take all the concepts from all facets, and use them for the counts
          */
         params.addValue("all_selected_facet_categories", facets.keySet());
-        String allConceptsForUnselectedCategories = categoryKeys.values().stream()
-            .map(key -> "SELECT * FROM facet_category_" + key + "_concepts").collect(Collectors.joining(" INTERSECT "));
+        String existsChainAll = categoryKeys.values().stream()
+            .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
+            .collect(Collectors.joining("\n                    AND "));
         String unselectedFacetsQuery = """
             UNION
             (
@@ -251,13 +255,13 @@ public class FacetQueryGenerator {
                 WHERE
                     %s
                     fc.name NOT IN (:all_selected_facet_categories)
-                    AND fcn.concept_node_id IN (%s)
+                    AND %s
                 GROUP BY
                     facet.facet_id
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentWhere, allConceptsForUnselectedCategories);
+            """.formatted(consentWhere, existsChainAll);
 
         return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 public class FacetQueryGenerator {
 
     private final String fcnQueryable;
+    private final String fcnQueryable2;
 
     private static final String CONSENT_QUERY = """
         dataset.dataset_id IN (
@@ -51,6 +52,7 @@ public class FacetQueryGenerator {
     @Autowired
     public FacetQueryGenerator(SchemaDetector schemaDetector) {
         this.fcnQueryable = schemaDetector.fcnQueryableClause("fcn");
+        this.fcnQueryable2 = schemaDetector.fcnQueryableClause("fcn2");
     }
 
     public String createFacetSQLAndPopulateParams(Filter filter, MapSqlParameterSource params) {
@@ -83,8 +85,9 @@ public class FacetQueryGenerator {
     }
 
     /**
-     * Returns independent count queries for multi-category facet requests, one per UNION block. Each query includes the shared CTEs and can
-     * be executed in parallel. Returns (facet_name, category_name, facet_count) rows for merging in Java.
+     * Returns independent count queries for multi-category facet requests, one per category block plus one for unselected categories. Each
+     * query uses inline subqueries against base tables (no CTEs) for optimal planner cardinality estimation. Returns (facet_name,
+     * category_name, facet_count) rows for merging in Java.
      */
     public List<QueryParamPair> createMultiCategoryCountBlocks(Filter filter) {
         Map<String, List<Facet>> groupedFacets =
@@ -106,36 +109,22 @@ public class FacetQueryGenerator {
             params.addValue("search", filter.search());
         }
 
-        // Build shared CTEs (same as existing multi-category methods)
-        String conceptsQuery = groupedFacets.keySet().stream().map(category -> {
-            List<String[]> selectedFacetsInCategory = groupedFacets.entrySet().stream().filter(e -> category.equals(e.getKey()))
-                .flatMap(e -> e.getValue().stream()).map(facet -> new String[] {facet.category(), facet.name()}).toList();
-            params.addValue("facets_in_cat_" + categoryKeys.get(category), selectedFacetsInCategory);
-            params.addValue("facet_category_" + categoryKeys.get(category), category);
-            String searchJoin = hasSearch ? "JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id" : "";
-            String searchWhere = hasSearch ? "AND " + QueryUtility.SEARCH_WHERE : "";
-            return """
-                facet_category_%s_concepts AS (
-                    SELECT DISTINCT(fcn.concept_node_id) as concept_node_id
-                    FROM facet
-                        JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                        %s
-                    WHERE %s
-                        AND (fc.name, facet.name) IN (:facets_in_cat_%s)
-                        %s
-                )""".formatted(categoryKeys.get(category), searchJoin, fcnQueryable, categoryKeys.get(category), searchWhere);
-        }).collect(Collectors.joining(",\n"));
-        String ctePrefix = "WITH " + conceptsQuery + "\n";
+        List<String[]> allSelectedFacets =
+            groupedFacets.values().stream().flatMap(List::stream).map(f -> new String[] {f.category(), f.name()}).toList();
+        params.addValue("all_selected_facets", allSelectedFacets);
+        params.addValue("num_categories", groupedFacets.size());
+        params.addValue("num_other_categories", groupedFacets.size() - 1);
+        params.addValue("all_selected_facet_categories", groupedFacets.keySet());
+        groupedFacets.keySet().forEach(category -> params.addValue("facet_category_" + categoryKeys.get(category), category));
+
+        String searchJoin = hasSearch ? "JOIN concept_node ON concept_node.concept_node_id = fcn2.concept_node_id" : "";
+        String searchWhere = hasSearch ? "AND " + QueryUtility.SEARCH_WHERE : "";
 
         List<QueryParamPair> blocks = new ArrayList<>();
 
-        // One block per selected category: filtered by OTHER categories' concepts
+        // One block per selected category: inline IN subquery excludes this category
         for (String category : groupedFacets.keySet()) {
-            String existsChain = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
-                .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
-                .collect(Collectors.joining("\n                AND "));
-            String block = ctePrefix + """
+            String block = """
                 SELECT facet.name AS facet_name, fc.name AS category_name, count(*) AS facet_count
                 FROM facet
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
@@ -143,19 +132,30 @@ public class FacetQueryGenerator {
                     %s
                 WHERE %s
                     AND %s
-                    %s
-                    AND fc.name = :facet_category_%s
+                    fc.name = :facet_category_%s
+                    AND fcn.concept_node_id IN (
+                        SELECT fcn2.concept_node_id
+                        FROM facet__concept_node fcn2
+                            JOIN facet f2 ON f2.facet_id = fcn2.facet_id
+                            JOIN facet_category fc2 ON fc2.facet_category_id = f2.facet_category_id
+                            %s
+                        WHERE %s
+                            AND fc2.name != :facet_category_%s
+                            AND (fc2.name, f2.name) IN (:all_selected_facets)
+                            %s
+                        GROUP BY fcn2.concept_node_id
+                        HAVING count(DISTINCT fc2.name) = :num_other_categories
+                    )
                 GROUP BY facet.name, fc.name
-                """.formatted(consentJoins, fcnQueryable, consentWhere, existsChain, categoryKeys.get(category));
+                """.formatted(
+                consentJoins, fcnQueryable, consentWhere, categoryKeys.get(category), searchJoin, fcnQueryable2, categoryKeys.get(category),
+                searchWhere
+            );
             blocks.add(new QueryParamPair(block, params));
         }
 
-        // One block for unselected categories: filtered by ALL categories' concepts
-        params.addValue("all_selected_facet_categories", groupedFacets.keySet());
-        String existsChainAll = categoryKeys.values().stream()
-            .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
-            .collect(Collectors.joining("\n                AND "));
-        String unselectedBlock = ctePrefix + """
+        // One block for unselected categories: inline IN subquery requires ALL categories
+        String unselectedBlock = """
             SELECT facet.name AS facet_name, fc.name AS category_name, count(*) AS facet_count
             FROM facet
                 JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
@@ -164,9 +164,20 @@ public class FacetQueryGenerator {
             WHERE %s
                 AND %s
                 fc.name NOT IN (:all_selected_facet_categories)
-                AND %s
+                AND fcn.concept_node_id IN (
+                    SELECT fcn2.concept_node_id
+                    FROM facet__concept_node fcn2
+                        JOIN facet f2 ON f2.facet_id = fcn2.facet_id
+                        JOIN facet_category fc2 ON fc2.facet_category_id = f2.facet_category_id
+                        %s
+                    WHERE %s
+                        AND (fc2.name, f2.name) IN (:all_selected_facets)
+                        %s
+                    GROUP BY fcn2.concept_node_id
+                    HAVING count(DISTINCT fc2.name) = :num_categories
+                )
             GROUP BY facet.name, fc.name
-            """.formatted(consentJoins, fcnQueryable, consentWhere, existsChainAll);
+            """.formatted(consentJoins, fcnQueryable, consentWhere, searchJoin, fcnQueryable2, searchWhere);
         blocks.add(new QueryParamPair(unselectedBlock, params));
 
         return blocks;
@@ -189,92 +200,76 @@ public class FacetQueryGenerator {
             LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
             LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
 
-        /*
-         * For each category of facet present in the filter, create a query that represents all the concept IDs associated with the selected
-         * facets in that category. Concept_node JOIN needed here for searchable_fields.
-         */
-        String conceptsQuery = "WITH " + facets.keySet().stream().map(category -> {
-            List<String[]> selectedFacetsInCateory = facets.entrySet().stream().filter(e -> category.equals(e.getKey()))
-                .flatMap(e -> e.getValue().stream()).map(facet -> new String[] {facet.category(), facet.name()}).toList();
-            params.addValue("facets_in_cat_" + categoryKeys.get(category), selectedFacetsInCateory);
-            params.addValue("facet_category_" + categoryKeys.get(category), category);
-            return """
-                facet_category_%s_concepts AS (
-                    SELECT
-                        DISTINCT(fcn.concept_node_id) as concept_node_id
-                    FROM
-                        facet
-                        JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                        JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                    WHERE
-                        %s
-                        AND (fc.name, facet.name) IN (:facets_in_cat_%s)
-                        AND %s
-                )
-                """.formatted(categoryKeys.get(category), fcnQueryable, categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
-        }).collect(Collectors.joining(",\n"));
-        /*
-         * Categories with no selected facets contribute no concepts, so ignore them for now. Now, for each category with selected facets,
-         * take all the concepts from all other categories with selections and INTERSECT them. This creates the concepts for this category
-         */
-        String selectedFacetsQuery = facets.keySet().stream().map(category -> {
-            String existsChain = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
-                .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
-                .collect(Collectors.joining("\n                    AND "));
-            params.addValue("", "");
-            return """
-                (
-                    SELECT
-                        facet.facet_id, count(*) as facet_count
-                    FROM
-                        facet
-                        LEFT JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
-                        JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                        %s
-                    WHERE
-                        %s
-                        AND %s
-                        %s
-                        AND fc.name = :facet_category_%s
-                    GROUP BY
-                        facet.facet_id
-                    ORDER BY
-                        facet_count DESC
-                )
-                """.formatted(consentJoins, fcnQueryable, consentWhere, existsChain, categoryKeys.get(category));
-        }).collect(Collectors.joining("\n\tUNION\n"));
-
-        /*
-         * For categories with no selected facets, take all the concepts from all facets, and use them for the counts
-         */
+        List<String[]> allSelectedFacets =
+            facets.values().stream().flatMap(List::stream).map(f -> new String[] {f.category(), f.name()}).toList();
+        params.addValue("all_selected_facets", allSelectedFacets);
+        params.addValue("num_categories", facets.size());
+        params.addValue("num_other_categories", facets.size() - 1);
         params.addValue("all_selected_facet_categories", facets.keySet());
-        String existsChainAll = categoryKeys.values().stream()
-            .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
-            .collect(Collectors.joining("\n                    AND "));
+        facets.keySet().forEach(category -> params.addValue("facet_category_" + categoryKeys.get(category), category));
+
+        // Each UNION block has an inline IN subquery with concept_node JOIN for search
+        String selectedFacetsQuery = facets.keySet().stream()
+            .map(
+                category -> """
+                    (
+                        SELECT facet.facet_id, count(*) AS facet_count
+                        FROM facet
+                            JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
+                            JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
+                            %s
+                        WHERE %s
+                            AND %s
+                            fc.name = :facet_category_%s
+                            AND fcn.concept_node_id IN (
+                                SELECT fcn2.concept_node_id
+                                FROM facet__concept_node fcn2
+                                    JOIN facet f2 ON f2.facet_id = fcn2.facet_id
+                                    JOIN facet_category fc2 ON fc2.facet_category_id = f2.facet_category_id
+                                    JOIN concept_node ON concept_node.concept_node_id = fcn2.concept_node_id
+                                WHERE %s
+                                    AND fc2.name != :facet_category_%s
+                                    AND (fc2.name, f2.name) IN (:all_selected_facets)
+                                    AND %s
+                                GROUP BY fcn2.concept_node_id
+                                HAVING count(DISTINCT fc2.name) = :num_other_categories
+                            )
+                        GROUP BY facet.facet_id
+                        ORDER BY facet_count DESC
+                    )""".formatted(
+                    consentJoins, fcnQueryable, consentWhere, categoryKeys.get(category), fcnQueryable2, categoryKeys.get(category),
+                    QueryUtility.SEARCH_WHERE
+                )
+            ).collect(Collectors.joining("\n\tUNION\n"));
+
         String unselectedFacetsQuery = """
             UNION
             (
-                SELECT
-                    facet.facet_id, count(*) as facet_count
-                FROM
-                    facet
-                    JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
+                SELECT facet.facet_id, count(*) AS facet_count
+                FROM facet
+                    JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                     %s
-                WHERE
-                    %s
+                WHERE %s
                     AND %s
                     fc.name NOT IN (:all_selected_facet_categories)
-                    AND %s
-                GROUP BY
-                    facet.facet_id
-                ORDER BY
-                    facet_count DESC
-            )
-            """.formatted(consentJoins, fcnQueryable, consentWhere, existsChainAll);
+                    AND fcn.concept_node_id IN (
+                        SELECT fcn2.concept_node_id
+                        FROM facet__concept_node fcn2
+                            JOIN facet f2 ON f2.facet_id = fcn2.facet_id
+                            JOIN facet_category fc2 ON fc2.facet_category_id = f2.facet_category_id
+                            JOIN concept_node ON concept_node.concept_node_id = fcn2.concept_node_id
+                        WHERE %s
+                            AND (fc2.name, f2.name) IN (:all_selected_facets)
+                            AND %s
+                        GROUP BY fcn2.concept_node_id
+                        HAVING count(DISTINCT fc2.name) = :num_categories
+                    )
+                GROUP BY facet.facet_id
+                ORDER BY facet_count DESC
+            )""".formatted(consentJoins, fcnQueryable, consentWhere, fcnQueryable2, QueryUtility.SEARCH_WHERE);
 
-        return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
+        return selectedFacetsQuery + "\n" + unselectedFacetsQuery;
     }
 
     private String createMultiCategorySQLNoSearch(Map<String, List<Facet>> facets, String consentWhere, MapSqlParameterSource params) {
@@ -283,91 +278,68 @@ public class FacetQueryGenerator {
             LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
             LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id""" : "";
 
-        /*
-         * For each category of facet present in the filter, create a query that represents all the concept IDs associated with the selected
-         * facets in that category
-         */
-        String conceptsQuery = "WITH " + facets.keySet().stream().map(category -> {
-            List<String[]> selectedFacetsInCateory = facets.entrySet().stream().filter(e -> category.equals(e.getKey()))
-                .flatMap(e -> e.getValue().stream()).map(facet -> new String[] {facet.category(), facet.name()}).toList();
-            params.addValue("facets_in_cat_" + categoryKeys.get(category), selectedFacetsInCateory);
-            params.addValue("facet_category_" + categoryKeys.get(category), category);
-            return """
-                facet_category_%s_concepts AS (
-                    SELECT
-                        DISTINCT(fcn.concept_node_id) as concept_node_id
-                    FROM
-                        facet
-                        JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                    WHERE
-                        %s
-                        AND (fc.name, facet.name) IN (:facets_in_cat_%s)
-                )
-                """.formatted(categoryKeys.get(category), fcnQueryable, categoryKeys.get(category));
-        }).collect(Collectors.joining(",\n"));
-        /*
-         * Now, for each category with selected facets, take all the concepts from all other categories with selections and INTERSECT them.
-         * This creates the concepts for this category
-         */
-        String selectedFacetsQuery = facets.keySet().stream().map(category -> {
-            params.addValue("facet_category_" + categoryKeys.get(category), category);
-            String existsChain = categoryKeys.values().stream().filter(key -> !categoryKeys.get(category).equals(key))
-                .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
-                .collect(Collectors.joining("\n                    AND "));
-            params.addValue("", "");
-            return """
-                (
-                    SELECT
-                        facet.facet_id, count(*) as facet_count
-                    FROM
-                        facet
-                        JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                        %s
-                    WHERE
-                        %s
-                        AND %s
-                        %s
-                        AND fc.name = :facet_category_%s
-                    GROUP BY
-                        facet.facet_id
-                    ORDER BY
-                        facet_count DESC
-                )
-                """.formatted(consentJoins, fcnQueryable, consentWhere, existsChain, categoryKeys.get(category));
-        }).collect(Collectors.joining("\n\tUNION\n"));
-
-        /*
-         * For categories with no selected facets, take all the concepts from all facets, and use them for the counts
-         */
+        List<String[]> allSelectedFacets =
+            facets.values().stream().flatMap(List::stream).map(f -> new String[] {f.category(), f.name()}).toList();
+        params.addValue("all_selected_facets", allSelectedFacets);
+        params.addValue("num_categories", facets.size());
+        params.addValue("num_other_categories", facets.size() - 1);
         params.addValue("all_selected_facet_categories", facets.keySet());
-        String existsChainAll = categoryKeys.values().stream()
-            .map(key -> "EXISTS (SELECT 1 FROM facet_category_" + key + "_concepts c WHERE c.concept_node_id = fcn.concept_node_id)")
-            .collect(Collectors.joining("\n                    AND "));
+        facets.keySet().forEach(category -> params.addValue("facet_category_" + categoryKeys.get(category), category));
+
+        // Each UNION block has an inline IN subquery against base tables (no CTE).
+        // This lets the planner see real pg_statistics and choose Hash Semi Join.
+        String selectedFacetsQuery = facets.keySet().stream().map(category -> """
+            (
+                SELECT facet.facet_id, count(*) AS facet_count
+                FROM facet
+                    JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
+                    JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
+                    %s
+                WHERE %s
+                    AND %s
+                    fc.name = :facet_category_%s
+                    AND fcn.concept_node_id IN (
+                        SELECT fcn2.concept_node_id
+                        FROM facet__concept_node fcn2
+                            JOIN facet f2 ON f2.facet_id = fcn2.facet_id
+                            JOIN facet_category fc2 ON fc2.facet_category_id = f2.facet_category_id
+                        WHERE %s
+                            AND fc2.name != :facet_category_%s
+                            AND (fc2.name, f2.name) IN (:all_selected_facets)
+                        GROUP BY fcn2.concept_node_id
+                        HAVING count(DISTINCT fc2.name) = :num_other_categories
+                    )
+                GROUP BY facet.facet_id
+                ORDER BY facet_count DESC
+            )""".formatted(consentJoins, fcnQueryable, consentWhere, categoryKeys.get(category), fcnQueryable2, categoryKeys.get(category)))
+            .collect(Collectors.joining("\n\tUNION\n"));
+
         String unselectedFacetsQuery = """
             UNION
             (
-                SELECT
-                    facet.facet_id, count(*) as facet_count
-                FROM
-                    facet
-                    JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
+                SELECT facet.facet_id, count(*) AS facet_count
+                FROM facet
+                    JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                     %s
-                WHERE
-                    %s
+                WHERE %s
                     AND %s
                     fc.name NOT IN (:all_selected_facet_categories)
-                    AND %s
-                GROUP BY
-                    facet.facet_id
-                ORDER BY
-                    facet_count DESC
-            )
-            """.formatted(consentJoins, fcnQueryable, consentWhere, existsChainAll);
+                    AND fcn.concept_node_id IN (
+                        SELECT fcn2.concept_node_id
+                        FROM facet__concept_node fcn2
+                            JOIN facet f2 ON f2.facet_id = fcn2.facet_id
+                            JOIN facet_category fc2 ON fc2.facet_category_id = f2.facet_category_id
+                        WHERE %s
+                            AND (fc2.name, f2.name) IN (:all_selected_facets)
+                        GROUP BY fcn2.concept_node_id
+                        HAVING count(DISTINCT fc2.name) = :num_categories
+                    )
+                GROUP BY facet.facet_id
+                ORDER BY facet_count DESC
+            )""".formatted(consentJoins, fcnQueryable, consentWhere, fcnQueryable2);
 
-        return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
+        return selectedFacetsQuery + "\n" + unselectedFacetsQuery;
     }
 
     private String createSingleCategorySQLWithSearch(List<Facet> facets, String search, String consentWhere, MapSqlParameterSource params) {

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -103,9 +103,9 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
                     WHERE
-                        (fc.name, facet.name) IN (:facets_in_cat_%s)
+                        concept_node.is_queryable = TRUE
+                        AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                         AND %s
                 )
                 """
@@ -193,9 +193,9 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
                     WHERE
-                        (fc.name, facet.name) IN (:facets_in_cat_%s)
+                        concept_node.is_queryable = TRUE
+                        AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                 )
                 """
                 .formatted(categoryKeys.get(category), categoryKeys.get(category));
@@ -284,9 +284,9 @@ public class FacetQueryGenerator {
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                    JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
                 WHERE
-                    %s
+                    concept_node.is_queryable = TRUE
+                    AND %s
                     fc.name = :facet_category_name
                     AND %s
                 GROUP BY
@@ -304,9 +304,9 @@ public class FacetQueryGenerator {
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
                     WHERE
-                        fc.name = :facet_category_name
+                        concept_node.is_queryable = TRUE
+                        AND fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                         AND %s
                 )
@@ -347,9 +347,9 @@ public class FacetQueryGenerator {
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                    JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
                 WHERE
-                    %s
+                    concept_node.is_queryable = TRUE
+                    AND %s
                     fc.name = :facet_category_name
                 GROUP BY
                     facet.facet_id
@@ -366,9 +366,9 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
                     WHERE
-                        fc.name = :facet_category_name
+                        concept_node.is_queryable = TRUE
+                        AND fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                 )
                 SELECT
@@ -406,9 +406,9 @@ public class FacetQueryGenerator {
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                 JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
             WHERE
-                %s
+                concept_node.is_queryable = TRUE
+                AND %s
                 %s
             GROUP BY
                 facet.facet_id
@@ -430,9 +430,9 @@ public class FacetQueryGenerator {
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                 JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                 LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                JOIN concept_node_meta AS categorical_values ON concept_node.concept_node_id = categorical_values.concept_node_id AND categorical_values.KEY = 'values' AND categorical_values.value <> ''
             WHERE
-                %s
+                concept_node.is_queryable = TRUE
+                AND %s
             GROUP BY
                 facet.facet_id
             ORDER BY

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -212,7 +212,7 @@ public class FacetQueryGenerator {
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                         AND %s
                 )
-                """.formatted(fcnQueryable, categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
+                """.formatted(categoryKeys.get(category), fcnQueryable, categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
         }).collect(Collectors.joining(",\n"));
         /*
          * Categories with no selected facets contribute no concepts, so ignore them for now. Now, for each category with selected facets,

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -84,10 +84,15 @@ public class FacetQueryGenerator {
     ) {
         Map<String, String> categoryKeys = createSQLSafeCategoryKeys(facets.keySet().stream().toList());
         params.addValue("search", search);
+        String consentJoins = StringUtils.hasLength(consentWhere)
+            ? """
+                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
+            : "";
 
         /*
          * For each category of facet present in the filter, create a query that represents all the concept IDs associated with the selected
-         * facets in that category
+         * facets in that category. Concept_node JOIN needed here for searchable_fields.
          */
         String conceptsQuery = "WITH " + facets.keySet().stream().map(category -> {
             List<String[]> selectedFacetsInCateory = facets.entrySet().stream().filter(e -> category.equals(e.getKey()))
@@ -97,14 +102,14 @@ public class FacetQueryGenerator {
             return """
                 facet_category_%s_concepts AS (
                     SELECT
-                        DISTINCT(concept_node.concept_node_id) as concept_node_id
+                        DISTINCT(fcn.concept_node_id) as concept_node_id
                     FROM
                         facet
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     WHERE
-                        concept_node.is_queryable = TRUE
+                        fcn.is_queryable = TRUE
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                         AND %s
                 )
@@ -128,10 +133,10 @@ public class FacetQueryGenerator {
                         facet
                         LEFT JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                        LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                    WHERE
                         %s
+                    WHERE
+                        fcn.is_queryable = TRUE
+                        AND %s
                         %s
                         AND fc.name = :facet_category_%s
                     GROUP BY
@@ -139,7 +144,7 @@ public class FacetQueryGenerator {
                     ORDER BY
                         facet_count DESC
                 )
-                """.formatted(consentWhere, existsChain, categoryKeys.get(category));
+                """.formatted(consentJoins, consentWhere, existsChain, categoryKeys.get(category));
         }).collect(Collectors.joining("\n\tUNION\n"));
 
         /*
@@ -158,10 +163,10 @@ public class FacetQueryGenerator {
                     facet
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                    LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                    LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                WHERE
                     %s
+                WHERE
+                    fcn.is_queryable = TRUE
+                    AND %s
                     fc.name NOT IN (:all_selected_facet_categories)
                     AND %s
                 GROUP BY
@@ -169,13 +174,18 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentWhere, existsChainAll);
+            """.formatted(consentJoins, consentWhere, existsChainAll);
 
         return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
     }
 
     private String createMultiCategorySQLNoSearch(Map<String, List<Facet>> facets, String consentWhere, MapSqlParameterSource params) {
         Map<String, String> categoryKeys = createSQLSafeCategoryKeys(facets.keySet().stream().toList());
+        String consentJoins = StringUtils.hasLength(consentWhere)
+            ? """
+                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
+            : "";
 
         /*
          * For each category of facet present in the filter, create a query that represents all the concept IDs associated with the selected
@@ -189,14 +199,13 @@ public class FacetQueryGenerator {
             return """
                 facet_category_%s_concepts AS (
                     SELECT
-                        DISTINCT(concept_node.concept_node_id) as concept_node_id
+                        DISTINCT(fcn.concept_node_id) as concept_node_id
                     FROM
                         facet
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                        JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     WHERE
-                        concept_node.is_queryable = TRUE
+                        fcn.is_queryable = TRUE
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                 )
                 """
@@ -220,10 +229,10 @@ public class FacetQueryGenerator {
                         facet
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                        LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                        LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                    WHERE
                         %s
+                    WHERE
+                        fcn.is_queryable = TRUE
+                        AND %s
                         %s
                         AND fc.name = :facet_category_%s
                     GROUP BY
@@ -231,7 +240,7 @@ public class FacetQueryGenerator {
                     ORDER BY
                         facet_count DESC
                 )
-                """.formatted(consentWhere, existsChain, categoryKeys.get(category));
+                """.formatted(consentJoins, consentWhere, existsChain, categoryKeys.get(category));
         }).collect(Collectors.joining("\n\tUNION\n"));
 
         /*
@@ -250,10 +259,10 @@ public class FacetQueryGenerator {
                     facet
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                    LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                    LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
-                WHERE
                     %s
+                WHERE
+                    fcn.is_queryable = TRUE
+                    AND %s
                     fc.name NOT IN (:all_selected_facet_categories)
                     AND %s
                 GROUP BY
@@ -261,7 +270,7 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentWhere, existsChainAll);
+            """.formatted(consentJoins, consentWhere, existsChainAll);
 
         return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
     }
@@ -270,14 +279,13 @@ public class FacetQueryGenerator {
         params.addValue("facet_category_name", facets.getFirst().category());
         params.addValue("facets", facets.stream().map(Facet::name).toList());
         params.addValue("search", search);
-        // return all the facets that
-        // are in the matched category
-        // are displayable
-        // match a concept with search hits
-        // UNION
-        // all the facets from other categories that match concepts that
-        // match selected facets from this category
-        // match search
+        String consentJoins = StringUtils.hasLength(consentWhere)
+            ? """
+                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
+            : "";
+        // Part 1: facets in the matched category that are displayable + match search
+        // Part 2: facets from other categories for concepts matching selected facets + search
         return """
             (
                 SELECT
@@ -289,7 +297,7 @@ public class FacetQueryGenerator {
                     JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                 WHERE
-                    concept_node.is_queryable = TRUE
+                    fcn.is_queryable = TRUE
                     AND %s
                     fc.name = :facet_category_name
                     AND %s
@@ -302,14 +310,14 @@ public class FacetQueryGenerator {
             (
                 WITH matching_concepts AS (
                     SELECT
-                        DISTINCT(concept_node.concept_node_id) AS concept_node_id
+                        DISTINCT(fcn.concept_node_id) AS concept_node_id
                     FROM
                         facet
-                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
+                        JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     WHERE
-                        concept_node.is_queryable = TRUE
+                        fcn.is_queryable = TRUE
                         AND fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                         AND %s
@@ -319,12 +327,12 @@ public class FacetQueryGenerator {
                 FROM
                     facet
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                    LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                    LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
+                    %s
                     JOIN matching_concepts ON fcn.concept_node_id = matching_concepts.concept_node_id
                 WHERE
-                    %s
+                    fcn.is_queryable = TRUE
+                    AND %s
                     fc.name <> :facet_category_name
                 GROUP BY
                     facet.facet_id
@@ -332,12 +340,17 @@ public class FacetQueryGenerator {
                     facet_count DESC
             )
             """
-            .formatted(consentWhere, QueryUtility.SEARCH_WHERE, QueryUtility.SEARCH_WHERE, consentWhere);
+            .formatted(consentWhere, QueryUtility.SEARCH_WHERE, QueryUtility.SEARCH_WHERE, consentJoins, consentWhere);
     }
 
     private String createSingleCategorySQLNoSearch(List<Facet> facets, String consentWhere, MapSqlParameterSource params) {
         params.addValue("facet_category_name", facets.getFirst().category());
         params.addValue("facets", facets.stream().map(Facet::name).toList());
+        String consentJoins = StringUtils.hasLength(consentWhere)
+            ? """
+                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
+            : "";
         // return all the facets in the matched category that are displayable
         // UNION
         // all the facets from other categories that match concepts that match selected facets from this category
@@ -349,10 +362,9 @@ public class FacetQueryGenerator {
                     facet
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                    JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                    LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
+                    %s
                 WHERE
-                    concept_node.is_queryable = TRUE
+                    fcn.is_queryable = TRUE
                     AND %s
                     fc.name = :facet_category_name
                 GROUP BY
@@ -364,14 +376,13 @@ public class FacetQueryGenerator {
             (
                 WITH matching_concepts AS (
                     SELECT
-                        DISTINCT(concept_node.concept_node_id) AS concept_node_id
+                        DISTINCT(fcn.concept_node_id) AS concept_node_id
                     FROM
                         facet
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                        JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     WHERE
-                        concept_node.is_queryable = TRUE
+                        fcn.is_queryable = TRUE
                         AND fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                 )
@@ -380,12 +391,12 @@ public class FacetQueryGenerator {
                 FROM
                     facet
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
-                    LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                    LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
+                    %s
                     JOIN matching_concepts ON fcn.concept_node_id = matching_concepts.concept_node_id
                 WHERE
-                    %s
+                    fcn.is_queryable = TRUE
+                    AND %s
                     fc.name <> :facet_category_name
                 GROUP BY
                     facet.facet_id
@@ -393,7 +404,7 @@ public class FacetQueryGenerator {
                     facet_count DESC
             )
             """
-            .formatted(consentWhere, consentWhere);
+            .formatted(consentJoins, consentWhere, consentJoins, consentWhere);
     }
 
     private String createNoFacetSQLWithSearch(String search, String consentWhere, MapSqlParameterSource params) {
@@ -401,6 +412,9 @@ public class FacetQueryGenerator {
         // match search
         // are displayable
         params.addValue("search", search);
+        String datasetJoin = StringUtils.hasLength(consentWhere)
+            ? "LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"
+            : "";
         return """
             SELECT
                 facet.facet_id, count(*) as facet_count
@@ -409,9 +423,9 @@ public class FacetQueryGenerator {
                 JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                 JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
+                %s
             WHERE
-                concept_node.is_queryable = TRUE
+                fcn.is_queryable = TRUE
                 AND %s
                 %s
             GROUP BY
@@ -419,11 +433,16 @@ public class FacetQueryGenerator {
             ORDER BY
                 facet_count DESC
             """
-            .formatted(consentWhere, QueryUtility.SEARCH_WHERE);
+            .formatted(datasetJoin, consentWhere, QueryUtility.SEARCH_WHERE);
 
     }
 
     private String createNoFacetSQLNoSearch(MapSqlParameterSource params, String consents) {
+        String consentJoins = StringUtils.hasLength(consents)
+            ? """
+                LEFT JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
+                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id"""
+            : "";
         String whereClause = StringUtils.hasLength(consents) ? consents.strip().replaceAll("\\s+AND\\s*$", "") : "TRUE";
         return """
             SELECT
@@ -432,16 +451,15 @@ public class FacetQueryGenerator {
                 facet
                 JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
-                JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
-                LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
+                %s
             WHERE
-                concept_node.is_queryable = TRUE
+                fcn.is_queryable = TRUE
                 AND %s
             GROUP BY
                 facet.facet_id
             ORDER BY
                 facet_count DESC
             """
-            .formatted(whereClause);
+            .formatted(consentJoins, whereClause);
     }
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGenerator.java
@@ -1,13 +1,14 @@
 package edu.harvard.dbmi.avillach.dictionary.facet;
 
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
+import edu.harvard.dbmi.avillach.dictionary.filter.QueryParamPair;
 import edu.harvard.dbmi.avillach.dictionary.util.QueryUtility;
+import edu.harvard.dbmi.avillach.dictionary.util.SchemaDetector;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-
-import edu.harvard.dbmi.avillach.dictionary.filter.QueryParamPair;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,6 +24,8 @@ import java.util.stream.Stream;
  */
 @Component
 public class FacetQueryGenerator {
+
+    private final String fcnQueryable;
 
     private static final String CONSENT_QUERY = """
         dataset.dataset_id IN (
@@ -44,6 +47,11 @@ public class FacetQueryGenerator {
                 (dataset.ref IN (:consents) AND consent.consent_code = '')
         ) AND
         """;
+
+    @Autowired
+    public FacetQueryGenerator(SchemaDetector schemaDetector) {
+        this.fcnQueryable = schemaDetector.fcnQueryableClause("fcn");
+    }
 
     public String createFacetSQLAndPopulateParams(Filter filter, MapSqlParameterSource params) {
         Map<String, List<Facet>> groupedFacets =
@@ -113,10 +121,10 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         %s
-                    WHERE fcn.is_queryable = TRUE
+                    WHERE %s
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                         %s
-                )""".formatted(categoryKeys.get(category), searchJoin, categoryKeys.get(category), searchWhere);
+                )""".formatted(categoryKeys.get(category), searchJoin, fcnQueryable, categoryKeys.get(category), searchWhere);
         }).collect(Collectors.joining(",\n"));
         String ctePrefix = "WITH " + conceptsQuery + "\n";
 
@@ -133,12 +141,12 @@ public class FacetQueryGenerator {
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                     JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
                     %s
-                WHERE fcn.is_queryable = TRUE
+                WHERE %s
                     AND %s
                     %s
                     AND fc.name = :facet_category_%s
                 GROUP BY facet.name, fc.name
-                """.formatted(consentJoins, consentWhere, existsChain, categoryKeys.get(category));
+                """.formatted(consentJoins, fcnQueryable, consentWhere, existsChain, categoryKeys.get(category));
             blocks.add(new QueryParamPair(block, params));
         }
 
@@ -153,12 +161,12 @@ public class FacetQueryGenerator {
                 JOIN facet_category fc ON fc.facet_category_id = facet.facet_category_id
                 JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                 %s
-            WHERE fcn.is_queryable = TRUE
+            WHERE %s
                 AND %s
                 fc.name NOT IN (:all_selected_facet_categories)
                 AND %s
             GROUP BY facet.name, fc.name
-            """.formatted(consentJoins, consentWhere, existsChainAll);
+            """.formatted(consentJoins, fcnQueryable, consentWhere, existsChainAll);
         blocks.add(new QueryParamPair(unselectedBlock, params));
 
         return blocks;
@@ -200,11 +208,11 @@ public class FacetQueryGenerator {
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     WHERE
-                        fcn.is_queryable = TRUE
+                        %s
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                         AND %s
                 )
-                """.formatted(categoryKeys.get(category), categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
+                """.formatted(fcnQueryable, categoryKeys.get(category), QueryUtility.SEARCH_WHERE);
         }).collect(Collectors.joining(",\n"));
         /*
          * Categories with no selected facets contribute no concepts, so ignore them for now. Now, for each category with selected facets,
@@ -225,7 +233,7 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         %s
                     WHERE
-                        fcn.is_queryable = TRUE
+                        %s
                         AND %s
                         %s
                         AND fc.name = :facet_category_%s
@@ -234,7 +242,7 @@ public class FacetQueryGenerator {
                     ORDER BY
                         facet_count DESC
                 )
-                """.formatted(consentJoins, consentWhere, existsChain, categoryKeys.get(category));
+                """.formatted(consentJoins, fcnQueryable, consentWhere, existsChain, categoryKeys.get(category));
         }).collect(Collectors.joining("\n\tUNION\n"));
 
         /*
@@ -255,7 +263,7 @@ public class FacetQueryGenerator {
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                     %s
                 WHERE
-                    fcn.is_queryable = TRUE
+                    %s
                     AND %s
                     fc.name NOT IN (:all_selected_facet_categories)
                     AND %s
@@ -264,7 +272,7 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentJoins, consentWhere, existsChainAll);
+            """.formatted(consentJoins, fcnQueryable, consentWhere, existsChainAll);
 
         return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
     }
@@ -293,10 +301,10 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     WHERE
-                        fcn.is_queryable = TRUE
+                        %s
                         AND (fc.name, facet.name) IN (:facets_in_cat_%s)
                 )
-                """.formatted(categoryKeys.get(category), categoryKeys.get(category));
+                """.formatted(categoryKeys.get(category), fcnQueryable, categoryKeys.get(category));
         }).collect(Collectors.joining(",\n"));
         /*
          * Now, for each category with selected facets, take all the concepts from all other categories with selections and INTERSECT them.
@@ -318,7 +326,7 @@ public class FacetQueryGenerator {
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         %s
                     WHERE
-                        fcn.is_queryable = TRUE
+                        %s
                         AND %s
                         %s
                         AND fc.name = :facet_category_%s
@@ -327,7 +335,7 @@ public class FacetQueryGenerator {
                     ORDER BY
                         facet_count DESC
                 )
-                """.formatted(consentJoins, consentWhere, existsChain, categoryKeys.get(category));
+                """.formatted(consentJoins, fcnQueryable, consentWhere, existsChain, categoryKeys.get(category));
         }).collect(Collectors.joining("\n\tUNION\n"));
 
         /*
@@ -348,7 +356,7 @@ public class FacetQueryGenerator {
                     JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                     %s
                 WHERE
-                    fcn.is_queryable = TRUE
+                    %s
                     AND %s
                     fc.name NOT IN (:all_selected_facet_categories)
                     AND %s
@@ -357,7 +365,7 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentJoins, consentWhere, existsChainAll);
+            """.formatted(consentJoins, fcnQueryable, consentWhere, existsChainAll);
 
         return conceptsQuery + selectedFacetsQuery + unselectedFacetsQuery;
     }
@@ -382,7 +390,7 @@ public class FacetQueryGenerator {
                     JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     LEFT JOIN dataset ON concept_node.dataset_id = dataset.dataset_id
                 WHERE
-                    fcn.is_queryable = TRUE
+                    %s
                     AND %s
                     fc.name = :facet_category_name
                     AND %s
@@ -402,7 +410,7 @@ public class FacetQueryGenerator {
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                         JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                     WHERE
-                        fcn.is_queryable = TRUE
+                        %s
                         AND fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                         AND %s
@@ -416,7 +424,7 @@ public class FacetQueryGenerator {
                     %s
                     JOIN matching_concepts ON fcn.concept_node_id = matching_concepts.concept_node_id
                 WHERE
-                    fcn.is_queryable = TRUE
+                    %s
                     AND %s
                     fc.name <> :facet_category_name
                 GROUP BY
@@ -424,7 +432,10 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentWhere, QueryUtility.SEARCH_WHERE, QueryUtility.SEARCH_WHERE, consentJoins, consentWhere);
+            """.formatted(
+            fcnQueryable, consentWhere, QueryUtility.SEARCH_WHERE, fcnQueryable, QueryUtility.SEARCH_WHERE, consentJoins, fcnQueryable,
+            consentWhere
+        );
     }
 
     private String createSingleCategorySQLNoSearch(List<Facet> facets, String consentWhere, MapSqlParameterSource params) {
@@ -446,7 +457,7 @@ public class FacetQueryGenerator {
                     JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     %s
                 WHERE
-                    fcn.is_queryable = TRUE
+                    %s
                     AND %s
                     fc.name = :facet_category_name
                 GROUP BY
@@ -464,7 +475,7 @@ public class FacetQueryGenerator {
                         JOIN facet__concept_node fcn ON fcn.facet_id = facet.facet_id
                         JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                     WHERE
-                        fcn.is_queryable = TRUE
+                        %s
                         AND fc.name = :facet_category_name
                         AND facet.name IN (:facets)
                 )
@@ -477,7 +488,7 @@ public class FacetQueryGenerator {
                     %s
                     JOIN matching_concepts ON fcn.concept_node_id = matching_concepts.concept_node_id
                 WHERE
-                    fcn.is_queryable = TRUE
+                    %s
                     AND %s
                     fc.name <> :facet_category_name
                 GROUP BY
@@ -485,7 +496,7 @@ public class FacetQueryGenerator {
                 ORDER BY
                     facet_count DESC
             )
-            """.formatted(consentJoins, consentWhere, consentJoins, consentWhere);
+            """.formatted(consentJoins, fcnQueryable, consentWhere, fcnQueryable, consentJoins, fcnQueryable, consentWhere);
     }
 
     private String createNoFacetSQLWithSearch(String search, String consentWhere, MapSqlParameterSource params) {
@@ -504,14 +515,14 @@ public class FacetQueryGenerator {
                 JOIN concept_node ON concept_node.concept_node_id = fcn.concept_node_id
                 %s
             WHERE
-                fcn.is_queryable = TRUE
+                %s
                 AND %s
                 %s
             GROUP BY
                 facet.facet_id
             ORDER BY
                 facet_count DESC
-            """.formatted(datasetJoin, consentWhere, QueryUtility.SEARCH_WHERE);
+            """.formatted(datasetJoin, fcnQueryable, consentWhere, QueryUtility.SEARCH_WHERE);
 
     }
 
@@ -529,12 +540,12 @@ public class FacetQueryGenerator {
                 JOIN facet_category fc on fc.facet_category_id = facet.facet_category_id
                 %s
             WHERE
-                fcn.is_queryable = TRUE
+                %s
                 AND %s
             GROUP BY
                 facet.facet_id
             ORDER BY
                 facet_count DESC
-            """.formatted(consentJoins, whereClause);
+            """.formatted(consentJoins, fcnQueryable, whereClause);
     }
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepository.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepository.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,9 @@ public class FacetRepository {
         this.mapper = mapper;
     }
 
+    @Transactional(readOnly = true)
     public List<FacetCategory> getFacets(Filter filter) {
+        template.getJdbcTemplate().execute("SET LOCAL work_mem = '64MB'");
         MapSqlParameterSource params = new MapSqlParameterSource();
         String innerSQL = generator.createFacetSQLAndPopulateParams(filter, params);
         // return a list of facets and the number of concepts associated with them

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepository.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepository.java
@@ -1,13 +1,19 @@
 package edu.harvard.dbmi.avillach.dictionary.facet;
 
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
+import edu.harvard.dbmi.avillach.dictionary.filter.QueryParamPair;
 import edu.harvard.dbmi.avillach.dictionary.util.MapExtractor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,6 +64,56 @@ public class FacetRepository {
                 .formatted(innerSQL);
 
         return template.query(sql, params, new FacetCategoryExtractor());
+    }
+
+    /**
+     * Returns all facets with metadata (category, display, parent, full_name) but no counts.
+     * Used as the base for merging parallel count results.
+     */
+    public List<FacetCategory> getFacetMetadata() {
+        String sql = """
+            SELECT
+                facet_category.name AS category_name,
+                parent_facet.name AS parent_name,
+                0 AS facet_count,
+                facet_category.display AS category_display,
+                facet_category.description AS category_description,
+                facet.name, facet.display, facet.description,
+                facet_meta_full_name.value AS full_name
+            FROM
+                facet
+                LEFT JOIN facet_category ON facet_category.facet_category_id = facet.facet_category_id
+                LEFT JOIN facet AS parent_facet ON facet.parent_id = parent_facet.facet_id
+                LEFT JOIN facet_meta AS facet_meta_full_name ON facet.facet_id = facet_meta_full_name.facet_id AND facet_meta_full_name.KEY = 'full_name'
+            """;
+        return template.query(sql, new FacetCategoryExtractor());
+    }
+
+    /**
+     * Executes a single count block on its own connection with work_mem set.
+     * Designed to be called from virtual threads for parallel execution.
+     * Returns a map of (category_name + "|" + facet_name) → count.
+     */
+    public Map<String, Integer> executeCountBlock(QueryParamPair block) throws SQLException {
+        DataSource ds = template.getJdbcTemplate().getDataSource();
+        try (Connection conn = ds.getConnection()) {
+            conn.setAutoCommit(false);
+            conn.setReadOnly(true);
+            conn.createStatement().execute("SET LOCAL work_mem = '64MB'");
+
+            NamedParameterJdbcTemplate localTemplate =
+                new NamedParameterJdbcTemplate(new SingleConnectionDataSource(conn, true));
+            Map<String, Integer> counts = localTemplate.query(block.query(), block.params(), rs -> {
+                Map<String, Integer> map = new HashMap<>();
+                while (rs.next()) {
+                    String key = rs.getString("category_name") + "|" + rs.getString("facet_name");
+                    map.put(key, rs.getInt("facet_count"));
+                }
+                return map;
+            });
+            conn.commit();
+            return counts;
+        }
     }
 
     public Map<String, String> getFacetCategoryOrder(List<String> categoryNames) {

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepository.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetRepository.java
@@ -67,32 +67,32 @@ public class FacetRepository {
     }
 
     /**
-     * Returns all facets with metadata (category, display, parent, full_name) but no counts.
-     * Used as the base for merging parallel count results.
+     * Returns all facets with metadata (category, display, parent, full_name) but no counts. Used as the base for merging parallel count
+     * results.
      */
     public List<FacetCategory> getFacetMetadata() {
-        String sql = """
-            SELECT
-                facet_category.name AS category_name,
-                parent_facet.name AS parent_name,
-                0 AS facet_count,
-                facet_category.display AS category_display,
-                facet_category.description AS category_description,
-                facet.name, facet.display, facet.description,
-                facet_meta_full_name.value AS full_name
-            FROM
-                facet
-                LEFT JOIN facet_category ON facet_category.facet_category_id = facet.facet_category_id
-                LEFT JOIN facet AS parent_facet ON facet.parent_id = parent_facet.facet_id
-                LEFT JOIN facet_meta AS facet_meta_full_name ON facet.facet_id = facet_meta_full_name.facet_id AND facet_meta_full_name.KEY = 'full_name'
-            """;
+        String sql =
+            """
+                SELECT
+                    facet_category.name AS category_name,
+                    parent_facet.name AS parent_name,
+                    0 AS facet_count,
+                    facet_category.display AS category_display,
+                    facet_category.description AS category_description,
+                    facet.name, facet.display, facet.description,
+                    facet_meta_full_name.value AS full_name
+                FROM
+                    facet
+                    LEFT JOIN facet_category ON facet_category.facet_category_id = facet.facet_category_id
+                    LEFT JOIN facet AS parent_facet ON facet.parent_id = parent_facet.facet_id
+                    LEFT JOIN facet_meta AS facet_meta_full_name ON facet.facet_id = facet_meta_full_name.facet_id AND facet_meta_full_name.KEY = 'full_name'
+                """;
         return template.query(sql, new FacetCategoryExtractor());
     }
 
     /**
-     * Executes a single count block on its own connection with work_mem set.
-     * Designed to be called from virtual threads for parallel execution.
-     * Returns a map of (category_name + "|" + facet_name) → count.
+     * Executes a single count block on its own connection with work_mem set. Designed to be called from virtual threads for parallel
+     * execution. Returns a map of (category_name + "|" + facet_name) → count.
      */
     public Map<String, Integer> executeCountBlock(QueryParamPair block) throws SQLException {
         DataSource ds = template.getJdbcTemplate().getDataSource();
@@ -101,8 +101,7 @@ public class FacetRepository {
             conn.setReadOnly(true);
             conn.createStatement().execute("SET LOCAL work_mem = '64MB'");
 
-            NamedParameterJdbcTemplate localTemplate =
-                new NamedParameterJdbcTemplate(new SingleConnectionDataSource(conn, true));
+            NamedParameterJdbcTemplate localTemplate = new NamedParameterJdbcTemplate(new SingleConnectionDataSource(conn, true));
             Map<String, Integer> counts = localTemplate.query(block.query(), block.params(), rs -> {
                 Map<String, Integer> map = new HashMap<>();
                 while (rs.next()) {

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetService.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetService.java
@@ -30,9 +30,8 @@ public class FacetService {
 
     @Cacheable("facets")
     public List<FacetCategory> getFacets(Filter filter) {
-        List<FacetCategory> facetCategories = isMultiCategory(filter)
-            ? getMultiCategoryFacetsParallel(filter)
-            : repository.getFacets(filter);
+        List<FacetCategory> facetCategories =
+            isMultiCategory(filter) ? getMultiCategoryFacetsParallel(filter) : repository.getFacets(filter);
 
         if (facetCategories.isEmpty()) {
             return facetCategories;
@@ -55,13 +54,15 @@ public class FacetService {
         // Execute count blocks in parallel using virtual threads
         Map<String, Integer> mergedCounts = new HashMap<>();
         try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
-            List<Future<Map<String, Integer>>> futures = blocks.stream()
-                .map(block -> executor.submit(() -> repository.executeCountBlock(block)))
-                .toList();
+            List<Future<Map<String, Integer>>> futures =
+                blocks.stream().map(block -> executor.submit(() -> repository.executeCountBlock(block))).toList();
 
             for (Future<Map<String, Integer>> future : futures) {
                 mergedCounts.putAll(future.get());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Parallel facet count execution interrupted", e);
         } catch (Exception e) {
             throw new RuntimeException("Parallel facet count execution failed", e);
         }
@@ -70,22 +71,20 @@ public class FacetService {
         List<FacetCategory> metadata = repository.getFacetMetadata();
 
         // Inject counts into metadata
-        return metadata.stream().map(cat -> new FacetCategory(
-            cat,
-            cat.facets().stream().map(f -> {
-                String key = f.category() + "|" + f.name();
-                int count = mergedCounts.getOrDefault(key, 0);
-                // Rebuild facet with count, preserving children with their own counts
-                List<Facet> children = f.children() == null ? List.of() : f.children().stream().map(child -> {
-                    String childKey = child.category() + "|" + child.name();
-                    int childCount = mergedCounts.getOrDefault(childKey, 0);
-                    return new Facet(child.name(), child.display(), child.description(), child.fullName(),
-                        childCount, child.children(), child.category(), child.meta());
-                }).toList();
-                return new Facet(f.name(), f.display(), f.description(), f.fullName(),
-                    count, children, f.category(), f.meta());
-            }).sorted(Comparator.comparingInt(Facet::count).reversed()).toList()
-        )).toList();
+        return metadata.stream().map(cat -> new FacetCategory(cat, cat.facets().stream().map(f -> {
+            String key = f.category() + "|" + f.name();
+            int count = mergedCounts.getOrDefault(key, 0);
+            // Rebuild facet with count, preserving children with their own counts
+            List<Facet> children = f.children() == null ? List.of() : f.children().stream().map(child -> {
+                String childKey = child.category() + "|" + child.name();
+                int childCount = mergedCounts.getOrDefault(childKey, 0);
+                return new Facet(
+                    child.name(), child.display(), child.description(), child.fullName(), childCount, child.children(), child.category(),
+                    child.meta()
+                );
+            }).toList();
+            return new Facet(f.name(), f.display(), f.description(), f.fullName(), count, children, f.category(), f.meta());
+        }).sorted(Comparator.comparingInt(Facet::count).reversed()).toList())).toList();
     }
 
     private List<FacetCategory> applyOrdering(List<FacetCategory> facetCategories) {

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetService.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetService.java
@@ -1,33 +1,94 @@
 package edu.harvard.dbmi.avillach.dictionary.facet;
 
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
+import edu.harvard.dbmi.avillach.dictionary.filter.QueryParamPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 @Service
 public class FacetService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(FacetService.class);
+
     private final FacetRepository repository;
+    private final FacetQueryGenerator generator;
 
     @Autowired
-    public FacetService(FacetRepository repository) {
+    public FacetService(FacetRepository repository, FacetQueryGenerator generator) {
         this.repository = repository;
+        this.generator = generator;
     }
 
     @Cacheable("facets")
     public List<FacetCategory> getFacets(Filter filter) {
-        List<FacetCategory> facetCategories = repository.getFacets(filter);
+        List<FacetCategory> facetCategories = isMultiCategory(filter)
+            ? getMultiCategoryFacetsParallel(filter)
+            : repository.getFacets(filter);
 
         if (facetCategories.isEmpty()) {
             return facetCategories;
         }
 
+        return applyOrdering(facetCategories);
+    }
+
+    private boolean isMultiCategory(Filter filter) {
+        if (filter.facets() == null || filter.facets().isEmpty()) {
+            return false;
+        }
+        long categoryCount = filter.facets().stream().map(Facet::category).distinct().count();
+        return categoryCount > 1;
+    }
+
+    private List<FacetCategory> getMultiCategoryFacetsParallel(Filter filter) {
+        List<QueryParamPair> blocks = generator.createMultiCategoryCountBlocks(filter);
+
+        // Execute count blocks in parallel using virtual threads
+        Map<String, Integer> mergedCounts = new HashMap<>();
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<Map<String, Integer>>> futures = blocks.stream()
+                .map(block -> executor.submit(() -> repository.executeCountBlock(block)))
+                .toList();
+
+            for (Future<Map<String, Integer>> future : futures) {
+                mergedCounts.putAll(future.get());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Parallel facet count execution failed", e);
+        }
+
+        // Get metadata (fast — just facet table data, no counts)
+        List<FacetCategory> metadata = repository.getFacetMetadata();
+
+        // Inject counts into metadata
+        return metadata.stream().map(cat -> new FacetCategory(
+            cat,
+            cat.facets().stream().map(f -> {
+                String key = f.category() + "|" + f.name();
+                int count = mergedCounts.getOrDefault(key, 0);
+                // Rebuild facet with count, preserving children with their own counts
+                List<Facet> children = f.children() == null ? List.of() : f.children().stream().map(child -> {
+                    String childKey = child.category() + "|" + child.name();
+                    int childCount = mergedCounts.getOrDefault(childKey, 0);
+                    return new Facet(child.name(), child.display(), child.description(), child.fullName(),
+                        childCount, child.children(), child.category(), child.meta());
+                }).toList();
+                return new Facet(f.name(), f.display(), f.description(), f.fullName(),
+                    count, children, f.category(), f.meta());
+            }).sorted(Comparator.comparingInt(Facet::count).reversed()).toList()
+        )).toList();
+    }
+
+    private List<FacetCategory> applyOrdering(List<FacetCategory> facetCategories) {
         List<String> categoryNames = facetCategories.stream().map(FacetCategory::name).toList();
         Map<String, String> order = repository.getFacetCategoryOrder(categoryNames);
 

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/QueryUtility.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/QueryUtility.java
@@ -28,7 +28,7 @@ public class QueryUtility {
      */
     private static final String TSQUERY_EXPR = "to_tsquery('english', regexp_replace(trim(:search), '\\s+', ':* & ', 'g') || ':*')";
 
-    public static final String SEARCH_QUERY = "ts_rank(searchable_fields, " + TSQUERY_EXPR + ")";
+    public static final String SEARCH_QUERY = "ts_rank_cd(searchable_fields, " + TSQUERY_EXPR + ")";
 
     /**
      * WHERE clause filter for full-text search. Uses the GIN-indexed searchable_fields tsvector column with prefix matching via to_tsquery.

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/SchemaDetector.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/SchemaDetector.java
@@ -6,13 +6,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Component
 public class SchemaDetector {
 
     private static final Logger LOG = LoggerFactory.getLogger(SchemaDetector.class);
 
-    private static final String CHECK_COLUMN_SQL =
-        "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = ? AND column_name = 'is_queryable')";
+    private static final String CHECK_COLUMN_SQL = """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = ?
+              AND column_name = 'is_queryable'
+        )
+        """;
 
     private final boolean conceptNodeQueryable;
     private final boolean fcnQueryable;
@@ -22,8 +31,8 @@ public class SchemaDetector {
         boolean cnQueryable = false;
         boolean fcnQ = false;
         try {
-            cnQueryable = Boolean.TRUE.equals(jdbcTemplate.queryForObject(CHECK_COLUMN_SQL, Boolean.class, "concept_node"));
-            fcnQ = Boolean.TRUE.equals(jdbcTemplate.queryForObject(CHECK_COLUMN_SQL, Boolean.class, "facet__concept_node"));
+            cnQueryable = Objects.requireNonNullElse(jdbcTemplate.queryForObject(CHECK_COLUMN_SQL, Boolean.class, "concept_node"), false);
+            fcnQ = Objects.requireNonNullElse(jdbcTemplate.queryForObject(CHECK_COLUMN_SQL, Boolean.class, "facet__concept_node"), false);
         } catch (Exception e) {
             LOG.warn("Schema detection failed ({}), defaulting to legacy query paths", e.getMessage());
         }
@@ -33,19 +42,6 @@ public class SchemaDetector {
             "Schema detection: concept_node.is_queryable {} | facet__concept_node.is_queryable {}",
             conceptNodeQueryable ? "found" : "NOT FOUND — legacy fallback", fcnQueryable ? "found" : "NOT FOUND — legacy fallback"
         );
-    }
-
-    /** For backward compatibility. */
-    public boolean hasQueryableColumn() {
-        return conceptNodeQueryable;
-    }
-
-    public boolean hasConceptNodeQueryable() {
-        return conceptNodeQueryable;
-    }
-
-    public boolean hasFcnQueryable() {
-        return fcnQueryable;
     }
 
     /**

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/SchemaDetector.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/SchemaDetector.java
@@ -3,12 +3,14 @@ package edu.harvard.dbmi.avillach.dictionary.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
 @Component
+@DependsOnDatabaseInitialization
 public class SchemaDetector {
 
     private static final Logger LOG = LoggerFactory.getLogger(SchemaDetector.class);

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/SchemaDetector.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/util/SchemaDetector.java
@@ -1,0 +1,74 @@
+package edu.harvard.dbmi.avillach.dictionary.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SchemaDetector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaDetector.class);
+
+    private static final String CHECK_COLUMN_SQL =
+        "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = ? AND column_name = 'is_queryable')";
+
+    private final boolean conceptNodeQueryable;
+    private final boolean fcnQueryable;
+
+    @Autowired
+    public SchemaDetector(JdbcTemplate jdbcTemplate) {
+        boolean cnQueryable = false;
+        boolean fcnQ = false;
+        try {
+            cnQueryable = Boolean.TRUE.equals(jdbcTemplate.queryForObject(CHECK_COLUMN_SQL, Boolean.class, "concept_node"));
+            fcnQ = Boolean.TRUE.equals(jdbcTemplate.queryForObject(CHECK_COLUMN_SQL, Boolean.class, "facet__concept_node"));
+        } catch (Exception e) {
+            LOG.warn("Schema detection failed ({}), defaulting to legacy query paths", e.getMessage());
+        }
+        this.conceptNodeQueryable = cnQueryable;
+        this.fcnQueryable = fcnQ;
+        LOG.info(
+            "Schema detection: concept_node.is_queryable {} | facet__concept_node.is_queryable {}",
+            conceptNodeQueryable ? "found" : "NOT FOUND — legacy fallback", fcnQueryable ? "found" : "NOT FOUND — legacy fallback"
+        );
+    }
+
+    /** For backward compatibility. */
+    public boolean hasQueryableColumn() {
+        return conceptNodeQueryable;
+    }
+
+    public boolean hasConceptNodeQueryable() {
+        return conceptNodeQueryable;
+    }
+
+    public boolean hasFcnQueryable() {
+        return fcnQueryable;
+    }
+
+    /**
+     * Returns a SQL WHERE clause fragment for concept_node queryability. Fast path: {@code alias.is_queryable = TRUE} Legacy fallback:
+     * EXISTS subquery against concept_node_meta.
+     */
+    public String conceptNodeQueryableClause(String alias) {
+        if (conceptNodeQueryable) {
+            return alias + ".is_queryable = TRUE";
+        }
+        return "EXISTS (SELECT 1 FROM concept_node_meta cnm_q WHERE cnm_q.concept_node_id = " + alias
+            + ".concept_node_id AND cnm_q.key = 'values' AND cnm_q.value <> '')";
+    }
+
+    /**
+     * Returns a SQL WHERE clause fragment for facet__concept_node queryability. Fast path: {@code alias.is_queryable = TRUE} Legacy
+     * fallback: EXISTS subquery joining concept_node_meta via concept_node.
+     */
+    public String fcnQueryableClause(String alias) {
+        if (fcnQueryable) {
+            return alias + ".is_queryable = TRUE";
+        }
+        return "EXISTS (SELECT 1 FROM concept_node_meta cnm_q WHERE cnm_q.concept_node_id = " + alias
+            + ".concept_node_id AND cnm_q.key = 'values' AND cnm_q.value <> '')";
+    }
+}

--- a/src/main/resources/application-bdc-dev.properties
+++ b/src/main/resources/application-bdc-dev.properties
@@ -4,6 +4,7 @@ spring.datasource.username=username
 spring.datasource.password=password
 spring.datasource.driver-class-name=org.postgresql.Driver
 server.port=80
+spring.datasource.hikari.maximum-pool-size=25
 
 dashboard.columns={abbreviation:'Abbreviation',name:'Name',clinvars:'Clinical Variables'}
 dashboard.column-order=abbreviation,name,clinvars

--- a/src/main/resources/application-bdc.properties
+++ b/src/main/resources/application-bdc.properties
@@ -15,3 +15,5 @@ logging.file.name=/var/log/dictionary.log
 server.tomcat.threads.max=300
 cache.duration-minutes=120
 cache.maximum-size=100000
+
+spring.datasource.hikari.maximum-pool-size=25

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGeneratorTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGeneratorTest.java
@@ -67,8 +67,8 @@ class FacetQueryGeneratorTest {
 
         List<IdCountPair> actual = template.query(query, params, new IdCountPairMapper());
         List<IdCountPair> expected = List.of(
-            new IdCountPair(20, 1), new IdCountPair(21, 2), new IdCountPair(22, 13), new IdCountPair(23, 2),
-            new IdCountPair(25, 2), new IdCountPair(26, 3), new IdCountPair(27, 3), new IdCountPair(28, 3), new IdCountPair(31, 3)
+            new IdCountPair(20, 1), new IdCountPair(21, 2), new IdCountPair(22, 13), new IdCountPair(23, 2), new IdCountPair(25, 2),
+            new IdCountPair(26, 3), new IdCountPair(27, 3), new IdCountPair(28, 3), new IdCountPair(31, 3)
         );
 
         Assertions.assertEquals(expected, byFacetId(actual));

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGeneratorTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetQueryGeneratorTest.java
@@ -17,6 +17,7 @@ import org.testcontainers.utility.MountableFile;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Comparator;
 import java.util.List;
 
 @Testcontainers
@@ -52,6 +53,11 @@ class FacetQueryGeneratorTest {
         }
     }
 
+    // Sort by facet_id for order-insensitive comparison when counts are tied
+    static List<IdCountPair> byFacetId(List<IdCountPair> list) {
+        return list.stream().sorted(Comparator.comparingInt(IdCountPair::facetId)).toList();
+    }
+
     @Test
     void shouldCountFacetsWithNoSearchAndNoSelectedFacetsAndNoConsents() {
         Filter filter = new Filter(List.of(), "", List.of());
@@ -61,11 +67,11 @@ class FacetQueryGeneratorTest {
 
         List<IdCountPair> actual = template.query(query, params, new IdCountPairMapper());
         List<IdCountPair> expected = List.of(
-            new IdCountPair(22, 13), new IdCountPair(26, 3), new IdCountPair(27, 3), new IdCountPair(28, 3), new IdCountPair(31, 3),
-            new IdCountPair(25, 2), new IdCountPair(21, 2), new IdCountPair(23, 2), new IdCountPair(20, 1)
+            new IdCountPair(20, 1), new IdCountPair(21, 2), new IdCountPair(22, 13), new IdCountPair(23, 2),
+            new IdCountPair(25, 2), new IdCountPair(26, 3), new IdCountPair(27, 3), new IdCountPair(28, 3), new IdCountPair(31, 3)
         );
 
-        Assertions.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, byFacetId(actual));
     }
 
     @Test
@@ -151,7 +157,7 @@ class FacetQueryGeneratorTest {
             new IdCountPair(28, 3), new IdCountPair(31, 3)
         );
 
-        Assertions.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, byFacetId(actual));
     }
 
     @Test

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/filter/FilterProcessorTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/filter/FilterProcessorTest.java
@@ -1,0 +1,66 @@
+package edu.harvard.dbmi.avillach.dictionary.filter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FilterProcessorTest {
+
+    @Test
+    void shouldReturnNullForNullInput() {
+        Assertions.assertNull(FilterProcessor.sanitizeSearch(null));
+    }
+
+    @Test
+    void shouldReturnEmptyForEmptyInput() {
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch(""));
+    }
+
+    @Test
+    void shouldReturnEmptyForWhitespaceOnly() {
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch("   "));
+    }
+
+    @Test
+    void shouldStripTsqueryOperators() {
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch("&"));
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch("|"));
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch("!"));
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch(":*"));
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch("()"));
+        Assertions.assertEquals("", FilterProcessor.sanitizeSearch("!@#$%"));
+    }
+
+    @Test
+    void shouldPreserveAlphanumericWords() {
+        Assertions.assertEquals("Asthma", FilterProcessor.sanitizeSearch("Asthma"));
+        Assertions.assertEquals("ear infection", FilterProcessor.sanitizeSearch("ear infection"));
+        Assertions.assertEquals("HbA1c", FilterProcessor.sanitizeSearch("HbA1c"));
+    }
+
+    @Test
+    void shouldStripSpecialCharsAndPreserveWords() {
+        Assertions.assertEquals("blood pressure", FilterProcessor.sanitizeSearch("blood & pressure"));
+        Assertions.assertEquals("C reactive protein", FilterProcessor.sanitizeSearch("C-reactive protein"));
+        Assertions.assertEquals("BMI 30", FilterProcessor.sanitizeSearch("BMI > 30"));
+    }
+
+    @Test
+    void shouldTrimAndCollapseWhitespace() {
+        Assertions.assertEquals("Asthma", FilterProcessor.sanitizeSearch("  Asthma  "));
+        Assertions.assertEquals("ear infection", FilterProcessor.sanitizeSearch("  ear   infection  "));
+    }
+
+    @Test
+    void shouldPreserveUnicodeLetters() {
+        Assertions.assertEquals("café", FilterProcessor.sanitizeSearch("café"));
+        Assertions.assertEquals("naïve", FilterProcessor.sanitizeSearch("naïve"));
+        Assertions.assertEquals("señor", FilterProcessor.sanitizeSearch("señor"));
+    }
+
+    @Test
+    void shouldCapLongSearchStrings() {
+        String longSearch = "a".repeat(300);
+        String result = FilterProcessor.sanitizeSearch(longSearch);
+        Assertions.assertEquals(200, result.length());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=dictionary
+spring.flyway.enabled=false
 spring.datasource.url=jdbc:postgresql://localhost:5432/search
 spring.datasource.username=picsure
 spring.datasource.password=foo

--- a/src/test/resources/seed.sql
+++ b/src/test/resources/seed.sql
@@ -52,7 +52,8 @@ CREATE TABLE public.concept_node (
     concept_type character varying(32) DEFAULT 'Interior'::character varying NOT NULL,
     concept_path character varying(10000) DEFAULT 'INVALID'::character varying NOT NULL,
     parent_id integer,
-    searchable_fields tsvector
+    searchable_fields tsvector,
+    is_queryable boolean NOT NULL DEFAULT FALSE
 );
 
 --
@@ -194,7 +195,8 @@ CREATE TABLE public.facet (
 CREATE TABLE public.facet__concept_node (
     facet__concept_node_id integer NOT NULL,
     facet_id integer NOT NULL,
-    concept_node_id integer NOT NULL
+    concept_node_id integer NOT NULL,
+    is_queryable boolean NOT NULL DEFAULT FALSE
 );
 
 --
@@ -1126,6 +1128,21 @@ INSERT INTO public.concept_node__remote_dictionary (CONCEPT_NODE_ID, REMOTE_DICT
     (229, 3), (230, 3), (233, 3), (234, 3), (235, 3), (237, 3), (238, 3), (239, 3), (240, 3), (242, 3),
     (244, 3), (245, 3), (246, 3), (248, 3), (249, 3), (251, 3), (252, 3), (253, 3), (254, 3), (255, 3),
     (256, 3), (257, 3), (258, 3), (261, 3), (264, 3), (266, 3), (267, 3), (268, 3), (269, 3);
+
+-- Backfill is_queryable: concepts with non-empty 'values' metadata are queryable
+UPDATE public.concept_node cn
+SET is_queryable = TRUE
+WHERE EXISTS (
+    SELECT 1 FROM public.concept_node_meta cnm
+    WHERE cnm.concept_node_id = cn.concept_node_id
+      AND cnm.key = 'values' AND cnm.value <> ''
+);
+
+-- Backfill facet__concept_node.is_queryable from concept_node.is_queryable
+UPDATE public.facet__concept_node fcn
+SET is_queryable = cn.is_queryable
+FROM public.concept_node cn
+WHERE cn.concept_node_id = fcn.concept_node_id;
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
### Description

This pull request introduces significant improvements to query performance for concepts and facets, leveraging parallel execution, indexing, and query optimizations.

- **Parallelization**: Enables parallel execution for concept count/retrieval and multi-category facet queries using virtual threads for improved performance and scalability.
- **Indexing and Backfill**: Adds `is_queryable` column and indexes to replace expensive JOINs, populating data via backfill scripts and maintaining consistency with triggers.
- **Optimized Query Logic**: Simplifies query conditions, aligns ranking with PostgreSQL best practices, and reduces redundant computations.
- **Transactional Support**: Introduces read-consistent transactional support to key query methods, ensuring smooth execution under high load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-category facet filtering now computes counts in parallel.
  * Query results are now consistently gated by an `is_queryable` flag.

* **Performance**
  * Parallelized concept listing/counting for faster response times.
  * Faster full-text search ranking via `ts_rank_cd`.
  * Query execution now uses a higher per-session `work_mem` and improved count-query generation.
  * Added indexes to speed up queryable facet filtering.

* **Refactor**
  * Search weighting switched to tier-based scoring (A–D).

* **Stability**
  * Safer, idempotent backfills and migrations; added triggers to keep queryable flags in sync.
  * Increased maximum database connection pool size for the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->