### PR TITLE
Add search facet metadata to audit logs in ConceptController

### DIFF
--- a/aggregate/pom.xml
+++ b/aggregate/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>edu.harvard.dbmi.avillach</groupId>
 			<artifactId>pic-sure-logging-client</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.0</version>
 		</dependency>
 	</dependencies>
 

--- a/aggregate/src/main/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilter.java
+++ b/aggregate/src/main/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilter.java
@@ -74,9 +74,6 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
                 AuditAttributes.getMetadata(request).forEach(metadata::putIfAbsent);
 
                 String caller = request.getHeader("X-Client-Type");
-                if (caller != null && !caller.isEmpty()) {
-                    metadata.put("caller", caller);
-                }
 
                 Map<String, Object> errorMap = null;
                 if (responseStatus >= 400) {
@@ -87,6 +84,7 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
 
                 LoggingEvent.Builder eventBuilder =
                     LoggingEvent.builder(eventType).action(action).sessionId(sessionId).request(requestInfo).metadata(metadata);
+                if (caller != null && !caller.isEmpty()) eventBuilder.caller(caller);
                 if (errorMap != null) eventBuilder.error(errorMap);
                 LoggingEvent event = eventBuilder.build();
 

--- a/aggregate/src/main/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilter.java
+++ b/aggregate/src/main/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilter.java
@@ -73,6 +73,11 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
 
                 AuditAttributes.getMetadata(request).forEach(metadata::putIfAbsent);
 
+                String caller = request.getHeader("X-Client-Type");
+                if (caller != null && !caller.isEmpty()) {
+                    metadata.put("caller", caller);
+                }
+
                 Map<String, Object> errorMap = null;
                 if (responseStatus >= 400) {
                     errorMap = new HashMap<>();

--- a/aggregate/src/test/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilterTest.java
+++ b/aggregate/src/test/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilterTest.java
@@ -1,0 +1,46 @@
+package edu.harvard.dbmi.avillach.dump;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import edu.harvard.dbmi.avillach.logging.LoggingClient;
+import edu.harvard.dbmi.avillach.logging.LoggingEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AuditLoggingFilterTest {
+
+    private LoggingEvent runFilterWith(MockHttpServletRequest request) throws Exception {
+        LoggingClient loggingClient = mock(LoggingClient.class);
+        when(loggingClient.isEnabled()).thenReturn(true);
+
+        AuditLoggingFilter filter = new AuditLoggingFilter(loggingClient, "10.0.0.1", 8080);
+        filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(loggingClient).send(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void recordsCallerFromXClientTypeHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/dump/concepts");
+        request.addHeader("X-Client-Type", "PYTHON_ADAPTER");
+
+        LoggingEvent event = runFilterWith(request);
+
+        assertEquals("PYTHON_ADAPTER", event.getMetadata().get("caller"));
+    }
+
+    @Test
+    void omitsCallerWhenHeaderAbsent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/dump/concepts");
+
+        LoggingEvent event = runFilterWith(request);
+
+        assertFalse(event.getMetadata().containsKey("caller"));
+    }
+}

--- a/aggregate/src/test/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilterTest.java
+++ b/aggregate/src/test/java/edu/harvard/dbmi/avillach/dump/AuditLoggingFilterTest.java
@@ -32,7 +32,7 @@ class AuditLoggingFilterTest {
 
         LoggingEvent event = runFilterWith(request);
 
-        assertEquals("PYTHON_ADAPTER", event.getMetadata().get("caller"));
+        assertEquals("PYTHON_ADAPTER", event.getCaller());
     }
 
     @Test
@@ -41,6 +41,6 @@ class AuditLoggingFilterTest {
 
         LoggingEvent event = runFilterWith(request);
 
-        assertFalse(event.getMetadata().containsKey("caller"));
+        assertNull(event.getCaller());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>edu.harvard.dbmi.avillach</groupId>
 			<artifactId>pic-sure-logging-client</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilter.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilter.java
@@ -75,9 +75,6 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
                 AuditAttributes.getMetadata(request).forEach(metadata::putIfAbsent);
 
                 String caller = request.getHeader("X-Client-Type");
-                if (caller != null && !caller.isEmpty()) {
-                    metadata.put("caller", caller);
-                }
 
                 Map<String, Object> errorMap = null;
                 if (responseStatus >= 400) {
@@ -88,6 +85,7 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
 
                 LoggingEvent.Builder eventBuilder =
                     LoggingEvent.builder(eventType).action(action).sessionId(sessionId).request(requestInfo).metadata(metadata);
+                if (caller != null && !caller.isEmpty()) eventBuilder.caller(caller);
                 if (errorMap != null) eventBuilder.error(errorMap);
                 LoggingEvent event = eventBuilder.build();
 

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilter.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilter.java
@@ -74,6 +74,11 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
 
                 AuditAttributes.getMetadata(request).forEach(metadata::putIfAbsent);
 
+                String caller = request.getHeader("X-Client-Type");
+                if (caller != null && !caller.isEmpty()) {
+                    metadata.put("caller", caller);
+                }
+
                 Map<String, Object> errorMap = null;
                 if (responseStatus >= 400) {
                     errorMap = new HashMap<>();

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -65,7 +65,10 @@ public class ConceptController {
 
         AuditAttributes.putMetadata(httpRequest, "search_term", filter.search() != null ? filter.search() : "");
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));
-        AuditAttributes.putMetadata(httpRequest, "search_facets", filter.facets() != null ? filter.facets().stream().map(Facet::fullName).collect(Collectors.joining(",")) : "");
+        AuditAttributes.putMetadata(
+            httpRequest, "search_facets",
+            filter.facets() != null ? filter.facets().stream().map(Facet::fullName).collect(Collectors.joining(",")) : ""
+        );
 
         return ResponseEntity.ok(pageResp);
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -2,6 +2,7 @@ package edu.harvard.dbmi.avillach.dictionary.concept;
 
 import edu.harvard.dbmi.avillach.dictionary.AuditAttributes;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.Concept;
+import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import edu.harvard.dbmi.avillach.logging.AuditEvent;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 @Controller
 public class ConceptController {
@@ -63,6 +65,7 @@ public class ConceptController {
 
         AuditAttributes.putMetadata(httpRequest, "search_term", filter.search() != null ? filter.search() : "");
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));
+        AuditAttributes.putMetadata(httpRequest, "search_facets", filter.facets() != null ? filter.facets().stream().map(Facet::fullName).collect(Collectors.joining(",")) : "");
 
         return ResponseEntity.ok(pageResp);
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -2,7 +2,6 @@ package edu.harvard.dbmi.avillach.dictionary.concept;
 
 import edu.harvard.dbmi.avillach.dictionary.AuditAttributes;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.Concept;
-import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import edu.harvard.dbmi.avillach.logging.AuditEvent;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,7 +18,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 @Controller
 public class ConceptController {
@@ -65,10 +63,7 @@ public class ConceptController {
 
         AuditAttributes.putMetadata(httpRequest, "search_term", filter.search() != null ? filter.search() : "");
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));
-        AuditAttributes.putMetadata(
-            httpRequest, "search_facets",
-            filter.facets() != null ? filter.facets().stream().map(Facet::name).collect(Collectors.joining(",")) : ""
-        );
+        AuditAttributes.putMetadata(httpRequest, "search_facets", filter.facets() != null ? filter.facets() : List.of());
 
         return ResponseEntity.ok(pageResp);
     }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -2,6 +2,7 @@ package edu.harvard.dbmi.avillach.dictionary.concept;
 
 import edu.harvard.dbmi.avillach.dictionary.AuditAttributes;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.Concept;
+import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import edu.harvard.dbmi.avillach.logging.AuditEvent;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,7 +15,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -63,9 +66,23 @@ public class ConceptController {
 
         AuditAttributes.putMetadata(httpRequest, "search_term", filter.search() != null ? filter.search() : "");
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));
-        AuditAttributes.putMetadata(httpRequest, "search_facets", filter.facets() != null ? filter.facets() : List.of());
+        AuditAttributes.putMetadata(httpRequest, "search_facets", reduceFacets(filter.facets()));
 
         return ResponseEntity.ok(pageResp);
+    }
+
+    // Reduce applied facets to {category, name} for the audit log — the full
+    // facet objects carry display/description/count/null fields that add noise.
+    private static List<Map<String, Object>> reduceFacets(List<Facet> facets) {
+        if (facets == null) {
+            return List.of();
+        }
+        return facets.stream().map(facet -> {
+            Map<String, Object> reduced = new LinkedHashMap<>();
+            reduced.put("category", facet.category());
+            reduced.put("name", facet.name());
+            return reduced;
+        }).toList();
     }
 
     @AuditEvent(type = "DATA_ACCESS", action = "concept.dump")

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -67,7 +67,7 @@ public class ConceptController {
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));
         AuditAttributes.putMetadata(
             httpRequest, "search_facets",
-            filter.facets() != null ? filter.facets().stream().map(Facet::fullName).collect(Collectors.joining(",")) : ""
+            filter.facets() != null ? filter.facets().stream().map(Facet::name).collect(Collectors.joining(",")) : ""
         );
 
         return ResponseEntity.ok(pageResp);

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptController.java
@@ -2,7 +2,7 @@ package edu.harvard.dbmi.avillach.dictionary.concept;
 
 import edu.harvard.dbmi.avillach.dictionary.AuditAttributes;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.Concept;
-import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
+import edu.harvard.dbmi.avillach.dictionary.facet.FacetService;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import edu.harvard.dbmi.avillach.logging.AuditEvent;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,9 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -26,6 +24,7 @@ import java.util.concurrent.Future;
 public class ConceptController {
 
     private final ConceptService conceptService;
+    private final FacetService facetService;
 
     @Autowired
     private HttpServletRequest httpRequest;
@@ -34,8 +33,9 @@ public class ConceptController {
     private Integer MAX_DEPTH;
 
 
-    public ConceptController(@Autowired ConceptService conceptService) {
+    public ConceptController(@Autowired ConceptService conceptService, @Autowired FacetService facetService) {
         this.conceptService = conceptService;
+        this.facetService = facetService;
     }
 
 
@@ -66,23 +66,9 @@ public class ConceptController {
 
         AuditAttributes.putMetadata(httpRequest, "search_term", filter.search() != null ? filter.search() : "");
         AuditAttributes.putMetadata(httpRequest, "result_count", String.valueOf(count));
-        AuditAttributes.putMetadata(httpRequest, "search_facets", reduceFacets(filter.facets()));
+        AuditAttributes.putMetadata(httpRequest, "search_facets", facetService.reduceFacets(filter.facets()));
 
         return ResponseEntity.ok(pageResp);
-    }
-
-    // Reduce applied facets to {category, name} for the audit log — the full
-    // facet objects carry display/description/count/null fields that add noise.
-    private static List<Map<String, Object>> reduceFacets(List<Facet> facets) {
-        if (facets == null) {
-            return List.of();
-        }
-        return facets.stream().map(facet -> {
-            Map<String, Object> reduced = new LinkedHashMap<>();
-            reduced.put("category", facet.category());
-            reduced.put("name", facet.name());
-            return reduced;
-        }).toList();
     }
 
     @AuditEvent(type = "DATA_ACCESS", action = "concept.dump")

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetService.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetService.java
@@ -105,4 +105,21 @@ public class FacetService {
     public Optional<Facet> facetDetails(String facetCategory, String facet) {
         return repository.getFacet(facetCategory, facet).map(f -> new Facet(f, repository.getFacetMeta(facetCategory, facet)));
     }
+
+    /**
+     * Reduce applied facets to a compact list of {@code {category, name}} objects. The full facet objects carry display/description/count
+     * and null fields that add noise; callers (e.g. audit logging) usually want only the identity of each selected facet. Returns an empty
+     * list when {@code facets} is null.
+     */
+    public List<Map<String, Object>> reduceFacets(List<Facet> facets) {
+        if (facets == null) {
+            return List.of();
+        }
+        return facets.stream().map(facet -> {
+            Map<String, Object> reduced = new LinkedHashMap<>();
+            reduced.put("category", facet.category());
+            reduced.put("name", facet.name());
+            return reduced;
+        }).toList();
+    }
 }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilterTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilterTest.java
@@ -1,0 +1,46 @@
+package edu.harvard.dbmi.avillach.dictionary;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import edu.harvard.dbmi.avillach.logging.LoggingClient;
+import edu.harvard.dbmi.avillach.logging.LoggingEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AuditLoggingFilterTest {
+
+    private LoggingEvent runFilterWith(MockHttpServletRequest request) throws Exception {
+        LoggingClient loggingClient = mock(LoggingClient.class);
+        when(loggingClient.isEnabled()).thenReturn(true);
+
+        AuditLoggingFilter filter = new AuditLoggingFilter(loggingClient, "10.0.0.1", 8080);
+        filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(loggingClient).send(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void recordsCallerFromXClientTypeHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/concepts");
+        request.addHeader("X-Client-Type", "PYTHON_ADAPTER");
+
+        LoggingEvent event = runFilterWith(request);
+
+        assertEquals("PYTHON_ADAPTER", event.getMetadata().get("caller"));
+    }
+
+    @Test
+    void omitsCallerWhenHeaderAbsent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/concepts");
+
+        LoggingEvent event = runFilterWith(request);
+
+        assertFalse(event.getMetadata().containsKey("caller"));
+    }
+}

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilterTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/AuditLoggingFilterTest.java
@@ -32,7 +32,7 @@ class AuditLoggingFilterTest {
 
         LoggingEvent event = runFilterWith(request);
 
-        assertEquals("PYTHON_ADAPTER", event.getMetadata().get("caller"));
+        assertEquals("PYTHON_ADAPTER", event.getCaller());
     }
 
     @Test
@@ -41,6 +41,6 @@ class AuditLoggingFilterTest {
 
         LoggingEvent event = runFilterWith(request);
 
-        assertFalse(event.getMetadata().containsKey("caller"));
+        assertNull(event.getCaller());
     }
 }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
@@ -1,5 +1,6 @@
 package edu.harvard.dbmi.avillach.dictionary.concept;
 
+import edu.harvard.dbmi.avillach.dictionary.AuditAttributes;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.CategoricalConcept;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.Concept;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.ContinuousConcept;
@@ -57,6 +58,22 @@ class ConceptControllerTest {
 
         Assertions.assertEquals(expected, actual.get().toList());
         Assertions.assertEquals(100L, actual.getTotalElements());
+    }
+
+    @Test
+    void shouldRecordSearchFacetsAsFacetObjects() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Facet facet = new Facet("phs000007", "Framingham", "desc", "phs000007", 3, null, "study_ids", null);
+        Filter filter = new Filter(List.of(facet), "heart", List.of());
+        Mockito.when(conceptService.listConcepts(filter, Pageable.ofSize(10).withPage(0))).thenReturn(List.of());
+        Mockito.when(conceptService.countConcepts(filter)).thenReturn(0L);
+
+        subject.listConcepts(filter, 0, 10);
+
+        Object searchFacets = AuditAttributes.getMetadata(request).get("search_facets");
+        Assertions.assertEquals(List.of(facet), searchFacets);
     }
 
     @Test

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
@@ -5,6 +5,7 @@ import edu.harvard.dbmi.avillach.dictionary.concept.model.CategoricalConcept;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.Concept;
 import edu.harvard.dbmi.avillach.dictionary.concept.model.ContinuousConcept;
 import edu.harvard.dbmi.avillach.dictionary.facet.Facet;
+import edu.harvard.dbmi.avillach.dictionary.facet.FacetService;
 import edu.harvard.dbmi.avillach.dictionary.filter.Filter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,9 @@ class ConceptControllerTest {
 
     @MockBean
     ConceptService conceptService;
+
+    @MockBean
+    FacetService facetService;
 
     @Autowired
     ConceptController subject;
@@ -61,25 +65,20 @@ class ConceptControllerTest {
     }
 
     @Test
-    void shouldRecordSearchFacetsAsReducedCategoryNameObjects() {
+    void shouldRecordSearchFacetsFromFacetService() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-        Facet continuous = new Facet("continuous", "Continuous", "desc", "continuous", 3, null, "data_type", null);
-        Facet framingham = new Facet("tutorial-biolincc_framingham", "Framingham", "desc", null, 1, null, "dataset_id", null);
-        Filter filter = new Filter(List.of(continuous, framingham), "heart", List.of());
+        Facet facet = new Facet("continuous", "Continuous", "desc", "continuous", 3, null, "data_type", null);
+        Filter filter = new Filter(List.of(facet), "heart", List.of());
+        List<Map<String, Object>> reduced = List.of(Map.of("category", "data_type", "name", "continuous"));
         Mockito.when(conceptService.listConcepts(filter, Pageable.ofSize(10).withPage(0))).thenReturn(List.of());
         Mockito.when(conceptService.countConcepts(filter)).thenReturn(0L);
+        Mockito.when(facetService.reduceFacets(filter.facets())).thenReturn(reduced);
 
         subject.listConcepts(filter, 0, 10);
 
-        Object searchFacets = AuditAttributes.getMetadata(request).get("search_facets");
-        Assertions.assertEquals(
-            List.of(
-                Map.of("category", "data_type", "name", "continuous"),
-                Map.of("category", "dataset_id", "name", "tutorial-biolincc_framingham")
-            ), searchFacets
-        );
+        Assertions.assertEquals(reduced, AuditAttributes.getMetadata(request).get("search_facets"));
     }
 
     @Test

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/concept/ConceptControllerTest.java
@@ -61,19 +61,25 @@ class ConceptControllerTest {
     }
 
     @Test
-    void shouldRecordSearchFacetsAsFacetObjects() {
+    void shouldRecordSearchFacetsAsReducedCategoryNameObjects() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-        Facet facet = new Facet("phs000007", "Framingham", "desc", "phs000007", 3, null, "study_ids", null);
-        Filter filter = new Filter(List.of(facet), "heart", List.of());
+        Facet continuous = new Facet("continuous", "Continuous", "desc", "continuous", 3, null, "data_type", null);
+        Facet framingham = new Facet("tutorial-biolincc_framingham", "Framingham", "desc", null, 1, null, "dataset_id", null);
+        Filter filter = new Filter(List.of(continuous, framingham), "heart", List.of());
         Mockito.when(conceptService.listConcepts(filter, Pageable.ofSize(10).withPage(0))).thenReturn(List.of());
         Mockito.when(conceptService.countConcepts(filter)).thenReturn(0L);
 
         subject.listConcepts(filter, 0, 10);
 
         Object searchFacets = AuditAttributes.getMetadata(request).get("search_facets");
-        Assertions.assertEquals(List.of(facet), searchFacets);
+        Assertions.assertEquals(
+            List.of(
+                Map.of("category", "data_type", "name", "continuous"),
+                Map.of("category", "dataset_id", "name", "tutorial-biolincc_framingham")
+            ), searchFacets
+        );
     }
 
     @Test

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetServiceTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionary/facet/FacetServiceTest.java
@@ -81,4 +81,24 @@ class FacetServiceTest {
 
         Assertions.assertEquals(expected, actual);
     }
+
+    @Test
+    void shouldReduceFacetsToCategoryAndName() {
+        Facet continuous = new Facet("continuous", "Continuous", "desc", "continuous", 3, null, "data_type", null);
+        Facet framingham = new Facet("tutorial-biolincc_framingham", "Framingham", "desc", null, 1, null, "dataset_id", null);
+
+        List<Map<String, Object>> actual = subject.reduceFacets(List.of(continuous, framingham));
+
+        Assertions.assertEquals(
+            List.of(
+                Map.of("category", "data_type", "name", "continuous"),
+                Map.of("category", "dataset_id", "name", "tutorial-biolincc_framingham")
+            ), actual
+        );
+    }
+
+    @Test
+    void shouldReduceNullFacetsToEmptyList() {
+        Assertions.assertEquals(List.of(), subject.reduceFacets(null));
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repository-managed Git hooks for pre-commit and pre-push when hooks are enabled.
  * Audit logging now records the request caller when provided, and includes recorded search facets in audit metadata.
* **Documentation**
  * Updated setup instructions to enable the hooks directory via `core.hooksPath`.
* **Tests**
  * Added unit tests for the new audit header and search facets behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->