### PR TITLE
ALS-12219: Schema-qualify dict tables in flyway migrations V7 and V10

### DIFF
--- a/db/flyway/V10__add_fcn_is_queryable.sql
+++ b/db/flyway/V10__add_fcn_is_queryable.sql
@@ -5,13 +5,13 @@
 --   2. trg_cascade_is_queryable_to_fcn: cascades concept_node.is_queryable changes
 
 
-ALTER TABLE facet__concept_node
+ALTER TABLE dict.facet__concept_node
     ADD COLUMN IF NOT EXISTS is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Backfill from concept_node.is_queryable (populated by V7)
-UPDATE facet__concept_node fcn
+UPDATE dict.facet__concept_node fcn
 SET is_queryable = cn.is_queryable
-FROM concept_node cn
+FROM dict.concept_node cn
 WHERE cn.concept_node_id = fcn.concept_node_id;
 
 -- Trigger 1: set is_queryable on fcn INSERT/UPDATE (covers ETL reload)
@@ -26,9 +26,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_set_fcn_is_queryable ON facet__concept_node;
+DROP TRIGGER IF EXISTS trg_set_fcn_is_queryable ON dict.facet__concept_node;
 CREATE TRIGGER trg_set_fcn_is_queryable
-    BEFORE INSERT OR UPDATE ON facet__concept_node
+    BEFORE INSERT OR UPDATE ON dict.facet__concept_node
     FOR EACH ROW EXECUTE FUNCTION dict.set_fcn_is_queryable();
 
 -- Trigger 2: cascade concept_node.is_queryable changes to fcn
@@ -43,16 +43,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_cascade_is_queryable_to_fcn ON concept_node;
+DROP TRIGGER IF EXISTS trg_cascade_is_queryable_to_fcn ON dict.concept_node;
 CREATE TRIGGER trg_cascade_is_queryable_to_fcn
-    AFTER UPDATE OF is_queryable ON concept_node
+    AFTER UPDATE OF is_queryable ON dict.concept_node
     FOR EACH ROW EXECUTE FUNCTION dict.cascade_is_queryable_to_fcn();
 
 -- Partial indexes (equivalent to matview indexes from Step 17B)
 CREATE INDEX IF NOT EXISTS idx_fcn_queryable_fid_cid
-    ON facet__concept_node(facet_id, concept_node_id)
+    ON dict.facet__concept_node(facet_id, concept_node_id)
     WHERE is_queryable = TRUE;
 
 CREATE INDEX IF NOT EXISTS idx_fcn_queryable_cid
-    ON facet__concept_node(concept_node_id)
+    ON dict.facet__concept_node(concept_node_id)
     WHERE is_queryable = TRUE;

--- a/db/flyway/V7__add_queryable_column.sql
+++ b/db/flyway/V7__add_queryable_column.sql
@@ -2,15 +2,15 @@
 -- Replaces the expensive JOIN concept_node_meta WHERE key='values' AND value<>''
 -- that was costing 932K index lookups per facet query.
 
-ALTER TABLE concept_node ADD COLUMN IF NOT EXISTS is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE dict.concept_node ADD COLUMN IF NOT EXISTS is_queryable BOOLEAN NOT NULL DEFAULT FALSE;
 
-UPDATE concept_node cn SET is_queryable = TRUE
+UPDATE dict.concept_node cn SET is_queryable = TRUE
 WHERE EXISTS (
-    SELECT 1 FROM concept_node_meta cnm
+    SELECT 1 FROM dict.concept_node_meta cnm
     WHERE cnm.concept_node_id = cn.concept_node_id
       AND cnm.key = 'values' AND cnm.value <> ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_concept_node_queryable
-    ON concept_node (concept_node_id)
+    ON dict.concept_node (concept_node_id)
     WHERE is_queryable = TRUE;


### PR DESCRIPTION
V7 and V10 referenced concept_node, concept_node_meta, and facet__concept_node without the dict schema prefix, relying on the session search_path resolving to dict. Qualify every table, trigger target, and index target with dict. so the migrations are correct regardless of search_path, matching V5/V6/V8/V9.

V8 and V9 were already fully qualified and are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking concepts and facet-concept links as queryable, with existing data backfilled automatically.
* **Bug Fixes**
  * Updated database changes to consistently use the correct schema names.
  * Improved handling of queryable flags so related records stay in sync after updates.
* **Performance**
  * Added indexes to help speed up lookups for queryable concepts and facet-concept relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->